### PR TITLE
Update Shiny Usage title and label

### DIFF
--- a/inst/apps/connect/app.R
+++ b/inst/apps/connect/app.R
@@ -1500,7 +1500,7 @@ shiny_apps_ui <- bslib::card(
     )
   ),
   bslib::card(
-    bslib::card_header("Shiny Session Trends"),
+    bslib::card_header("Shiny Sessions by Day"),
     shinycssloaders::withSpinner(plotly::plotlyOutput("shiny_trend_plot"))
   ),
   bslib::card(
@@ -1734,7 +1734,7 @@ shiny_apps_server <- function(input, output, session) {
       ggplot2::geom_line(linewidth = 0.5) +
       ggplot2::geom_point(size = 0.5) +
       ggplot2::theme_minimal() +
-      ggplot2::labs(x = "", y = "Count", color = "") +
+      ggplot2::labs(x = "", y = "Sessions", color = "") +
       ggplot2::scale_color_manual(
         values = c(
           "Total Sessions" = BRAND_COLORS$BURGUNDY,


### PR DESCRIPTION
https://github.com/rstudio/chronicle/issues/2527 listed: shiny usage - separate charts; update title/labels

But the chart for Shiny usage was already a single line of Total Sessions.

- Updated chart title to be `Shiny Sessions by Day`
- Updated y-axis title from `Count` to `Sessions`


<img width="767" height="587" alt="Screenshot 2026-01-14 at 10 46 20 AM" src="https://github.com/user-attachments/assets/ab665691-13c9-4ca0-8c85-07abdc90a820" />
