### PR TITLE
Add connect-gallery-action to publish a feed that could be used as part of the Connect Gallery

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,0 +1,43 @@
+name: Extensions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  extensions:
+    strategy:
+      fail-fast: false
+      matrix:
+        extension:
+          - connect
+          - workbench
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: posit-dev/connect-gallery-action/build-extension@main
+        with:
+          extension-name: ${{ matrix.extension }}
+          extensions-dir: inst/apps
+          release: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+
+  update-gallery:
+    runs-on: ubuntu-latest
+    needs: [extensions]
+    if: always() && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: posit-dev/connect-gallery-action@main
+        with:
+          extensions-dir: inst/apps

--- a/Dockerfile.manifests
+++ b/Dockerfile.manifests
@@ -15,7 +15,7 @@ ENV LANG=en_US.UTF-8
 # it does not have an impact on the renv or manifest files we generate
 ENV CRAN="https://p3m.dev/cran/__linux__/noble/latest"
 
-RUN Rscript -e 'install.packages(c("rsconnect", "renv", "remotes"), repos = Sys.getenv("CRAN"))'
+RUN Rscript -e 'install.packages(c("rsconnect", "renv", "remotes", "jsonlite"), repos = Sys.getenv("CRAN"))'
 
 ARG GIT_BRANCH=main
 
@@ -31,7 +31,19 @@ CMD ["Rscript", "-e", "\
   app_dirs <- c('inst/apps/connect', 'inst/apps/workbench'); \
   for (app_dir in app_dirs) { \
     message('Processing: ', app_dir); \
+    manifest_path <- file.path(app_dir, 'manifest.json'); \
+    ext_meta <- NULL; \
+    if (file.exists(manifest_path)) { \
+      old <- jsonlite::fromJSON(manifest_path, simplifyVector = FALSE); \
+      ext_meta <- old$extension; \
+    }; \
     renv::snapshot(project = app_dir, prompt = FALSE, force = TRUE); \
     rsconnect::writeManifest(appDir = app_dir); \
+    if (!is.null(ext_meta)) { \
+      manifest <- jsonlite::fromJSON(manifest_path, simplifyVector = FALSE); \
+      manifest <- c(list(extension = ext_meta), manifest); \
+      jsonlite::write_json(manifest, manifest_path, auto_unbox = TRUE, pretty = TRUE); \
+      message('Restored extension metadata for: ', app_dir); \
+    }; \
   } \
 "]

--- a/gallery.json
+++ b/gallery.json
@@ -1,0 +1,9 @@
+{
+  "categories": [
+    {
+      "id": "chronicle-reports",
+      "title": "Chronicle Reports",
+      "description": "Usage analytics dashboards powered by Posit Chronicle data."
+    }
+  ]
+}

--- a/inst/apps/connect/manifest.json
+++ b/inst/apps/connect/manifest.json
@@ -1,6 +1,6 @@
 {
   "extension": {
-    "name": "connect-chroncile",
+    "name": "connect",
     "title": "Chronicle Connect Dashboard",
     "description": "Comprehensive Posit Connect usage analytics — tracks licensed users, daily active users, publishers, content metrics, and usage patterns over time.",
     "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/connect",

--- a/inst/apps/connect/manifest.json
+++ b/inst/apps/connect/manifest.json
@@ -1,4 +1,15 @@
 {
+  "extension": {
+    "name": "connect-chroncile",
+    "title": "Chronicle Connect Dashboard",
+    "description": "Comprehensive Posit Connect usage analytics — tracks licensed users, daily active users, publishers, content metrics, and usage patterns over time.",
+    "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/connect",
+    "category": "chronicle-reports",
+    "tags": ["Chronicle reports"],
+    "minimumConnectVersion": "2025.01.0",
+    "requiredFeatures": [],
+    "version": "0.0.1"
+  },
   "version": 1,
   "locale": "en_US",
   "platform": "4.5.2",

--- a/inst/apps/workbench/manifest.json
+++ b/inst/apps/workbench/manifest.json
@@ -1,6 +1,6 @@
 {
   "extension": {
-    "name": "workbench-chroncile",
+    "name": "workbench",
     "title": "Chronicle Workbench Dashboard",
     "description": "Comprehensive Posit Workbench usage analytics — tracks licensed users, daily active users, session metrics, and admin activity over time.",
     "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/workbench",

--- a/inst/apps/workbench/manifest.json
+++ b/inst/apps/workbench/manifest.json
@@ -1,4 +1,15 @@
 {
+  "extension": {
+    "name": "workbench-chroncile",
+    "title": "Chronicle Workbench Dashboard",
+    "description": "Comprehensive Posit Workbench usage analytics — tracks licensed users, daily active users, session metrics, and admin activity over time.",
+    "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/workbench",
+    "category": "chronicle-reports",
+    "tags": ["Chronicle reports"],
+    "minimumConnectVersion": "2025.01.0",
+    "requiredFeatures": [],
+    "version": "0.0.1"
+  },
   "version": 1,
   "locale": "en_US",
   "platform": "4.5.2",


### PR DESCRIPTION
Uses the action at https://github.com/posit-dev/connect-gallery-action. Once this is merged, I can help get this added to an internal server so we can test it there (the TL;DR is adding the following block to the config, though we could add this as part of the default galleries that are available).

```
[GalleryFeed "Chronicle Reports"]
URL = "https://raw.githubusercontent.com/posit-dev/chroncile-reports/refs/heads/main/extensions.json"
Name = "Chronicle Reports"
Description = "Chronicle Reports"
Repo = "https://github.com/posit-dev/chronicle-reports"
```