### PR TITLE
update to use token from github app

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -18,10 +18,22 @@ jobs:
           - connect
           - workbench
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
+      - name: Generate token for GitHub App
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.POSIT_CHRONICLE_APP_ID }}
+          private-key: ${{ secrets.POSIT_CHRONICLE_PEM }}
+          permission-actions: read
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action/build-extension@main
         with:
@@ -34,10 +46,23 @@ jobs:
     needs: [extensions]
     if: always() && github.ref == 'refs/heads/dev'
     steps:
+      - name: Generate token for GitHub App
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.POSIT_CHRONICLE_APP_ID }}
+          private-key: ${{ secrets.POSIT_CHRONICLE_PEM }}
+          permission-actions: read
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
       - uses: actions/checkout@v4
         with:
           ref: dev
+          token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action@main
         with:
           extensions-dir: inst/apps
+


### PR DESCRIPTION
Following-up on workweek session, this sets up the github token via the github app, which _should_ (hopefully) allow the extension to update properly. I've also added the app to the bypass list.

---

This pull request updates the GitHub Actions workflow for extensions to use a GitHub App token for authentication instead of the default `GITHUB_TOKEN`. The changes improve security and allow for more granular permissions when running workflow jobs.

**Authentication and permissions improvements:**

* Added a step to generate a GitHub App token using `actions/create-github-app-token@v2`, leveraging the `POSIT_CHRONICLE_APP_ID` and `POSIT_CHRONICLE_PEM` secrets for authentication, and specifying fine-grained permissions for actions, contents, pull requests, and issues. [[1]](diffhunk://#diff-310dbe28c2700c802b7384a9fdee09b97060365abc8f898ce29b35f6d5f4e87eL21-R36) [[2]](diffhunk://#diff-310dbe28c2700c802b7384a9fdee09b97060365abc8f898ce29b35f6d5f4e87eR49-R68)
* Updated the `actions/checkout@v4` steps to use the generated GitHub App token, ensuring all subsequent actions run with the appropriate permissions. [[1]](diffhunk://#diff-310dbe28c2700c802b7384a9fdee09b97060365abc8f898ce29b35f6d5f4e87eL21-R36) [[2]](diffhunk://#diff-310dbe28c2700c802b7384a9fdee09b97060365abc8f898ce29b35f6d5f4e87eR49-R68)

These changes enhance the workflow's security posture and provide more control over repository access during CI/CD operations.