### PR TITLE
Extensions gh token

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -40,6 +40,9 @@ jobs:
 
   update-gallery:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     needs: [extensions]
     if: always() && github.ref == 'refs/heads/dev'
     steps:


### PR DESCRIPTION
It looks like the gallery action still needs GH_TOKEN - even though the interaction with chronicle-reports is using the app token