### PR TITLE
update manifest.R to use `>=` instead of `~=` for R version

### DIFF
--- a/inst/apps/connect/manifest.json
+++ b/inst/apps/connect/manifest.json
@@ -195,7 +195,7 @@
         "Maintainer": "Jonathan Keane <jkeane@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-04-29 13:00:15 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:55:40 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:35:07 UTC; unix"
       }
     },
     "askpass": {
@@ -328,7 +328,7 @@
         "Maintainer": "Michael Chirico <michaelchirico4@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-19 09:40:02 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:48:26 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:27:10 UTC; unix"
       }
     },
     "bsicons": {
@@ -388,7 +388,7 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-16 08:10:07 UTC",
-        "Built": "R 4.1.3; ; 2026-06-09 17:57:16 UTC; unix"
+        "Built": "R 4.1.3; ; 2026-06-09 18:36:53 UTC; unix"
       }
     },
     "cachem": {
@@ -475,16 +475,16 @@
         "RemoteRepo": "chronicle-reports",
         "RemoteUsername": "posit-dev",
         "RemoteRef": "dev",
-        "RemoteSha": "2c25b4f846e0bcc44690f8f91801b3b28a3a6cff",
+        "RemoteSha": "39c8c23f3c0a2c8aff553d2e1f2eb60078e67fcd",
         "GithubRepo": "chronicle-reports",
         "GithubUsername": "posit-dev",
         "GithubRef": "dev",
-        "GithubSHA1": "2c25b4f846e0bcc44690f8f91801b3b28a3a6cff",
+        "GithubSHA1": "39c8c23f3c0a2c8aff553d2e1f2eb60078e67fcd",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-09 17:57:38 UTC; root",
+        "Packaged": "2026-06-10 13:10:29 UTC; root",
         "Author": "Mark Tucker [aut, cre],\n  Matt Urbina [aut],\n  Posit Software, PBC [cph, fnd] (03wc8by49)",
         "Maintainer": "Mark Tucker <mark.tucker@posit.co>",
-        "Built": "R 4.1.3; ; 2026-06-09 17:57:39 UTC; unix"
+        "Built": "R 4.1.3; ; 2026-06-10 13:10:29 UTC; unix"
       }
     },
     "cli": {
@@ -568,7 +568,7 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-06 14:40:12 UTC",
-        "Built": "R 4.1.3; ; 2026-06-09 17:46:42 UTC; unix"
+        "Built": "R 4.1.3; ; 2026-06-09 18:25:22 UTC; unix"
       }
     },
     "crosstalk": {
@@ -651,7 +651,7 @@
         "Maintainer": "Tyson Barrett <t.barrett88@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-06 05:10:20 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:47:46 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:26:29 UTC; unix"
       }
     },
     "digest": {
@@ -1092,7 +1092,7 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2026-03-18 06:12:59 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:48:32 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:27:17 UTC; unix"
       }
     },
     "httr": {
@@ -1151,7 +1151,7 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-12-07 06:10:07 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:48:16 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:27:00 UTC; unix"
       }
     },
     "jquerylib": {
@@ -1287,7 +1287,7 @@
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2026-03-05 07:50:02 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:46:43 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:25:23 UTC; unix"
       }
     },
     "lazyeval": {
@@ -1483,7 +1483,7 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-14 14:50:14 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:38:09 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:21:36 UTC; unix"
       }
     },
     "otel": {
@@ -1722,7 +1722,7 @@
         "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-16 21:50:15 UTC",
-        "Built": "R 4.1.3; ; 2026-06-09 17:37:59 UTC; unix"
+        "Built": "R 4.1.3; ; 2026-06-09 18:21:25 UTC; unix"
       }
     },
     "rlang": {
@@ -2053,10 +2053,10 @@
         "GithubRef": "HEAD",
         "GithubSHA1": "c51fe5d0f7fda6dc142fc7212f1727de4d10e664",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-06-09 17:45:45 UTC; root",
+        "Packaged": "2026-06-09 18:24:24 UTC; root",
         "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  Posit Software, PBC [cph, fnd] (03wc8by49)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:45:45 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:24:24 UTC; unix"
       }
     },
     "tidyr": {
@@ -2088,7 +2088,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-12-19 09:20:02 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:57:18 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:36:56 UTC; unix"
       }
     },
     "tidyselect": {
@@ -2145,7 +2145,7 @@
         "Maintainer": "Vitalie Spinu <spinuvit@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-01-29 22:20:08 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:48:20 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:27:04 UTC; unix"
       }
     },
     "tinytex": {
@@ -2340,7 +2340,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "RSPM",
         "Date/Publication": "2026-06-01 05:10:03 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:46:40 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:25:20 UTC; unix"
       }
     },
     "xtable": {
@@ -2400,10 +2400,10 @@
   },
   "files": {
     "app.R": {
-      "checksum": "d72489cfeda309c3c259a17ad29f1593"
+      "checksum": "059102ea0e21d7cecb6bc61d7d27b27c"
     },
     "renv.lock": {
-      "checksum": "464a9e4c9d2ec946a81da80bdf1d6d60"
+      "checksum": "a3f519e4abf87f44e592b24ba8e4f7e3"
     }
   },
   "users": null

--- a/inst/apps/connect/renv.lock
+++ b/inst/apps/connect/renv.lock
@@ -576,7 +576,7 @@
       "RemoteRepo": "chronicle-reports",
       "RemoteUsername": "posit-dev",
       "RemoteRef": "dev",
-      "RemoteSha": "2c25b4f846e0bcc44690f8f91801b3b28a3a6cff",
+      "RemoteSha": "39c8c23f3c0a2c8aff553d2e1f2eb60078e67fcd",
       "NeedsCompilation": "no",
       "Author": "Mark Tucker [aut, cre], Matt Urbina [aut], Posit Software, PBC [cph, fnd] (03wc8by49)",
       "Maintainer": "Mark Tucker <mark.tucker@posit.co>"

--- a/inst/apps/workbench/manifest.json
+++ b/inst/apps/workbench/manifest.json
@@ -195,7 +195,7 @@
         "Maintainer": "Jonathan Keane <jkeane@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-04-29 13:00:15 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:55:40 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:35:07 UTC; unix"
       }
     },
     "askpass": {
@@ -328,7 +328,7 @@
         "Maintainer": "Michael Chirico <michaelchirico4@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-19 09:40:02 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:48:26 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:27:10 UTC; unix"
       }
     },
     "bsicons": {
@@ -388,7 +388,7 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-16 08:10:07 UTC",
-        "Built": "R 4.1.3; ; 2026-06-09 17:57:16 UTC; unix"
+        "Built": "R 4.1.3; ; 2026-06-09 18:36:53 UTC; unix"
       }
     },
     "cachem": {
@@ -475,16 +475,16 @@
         "RemoteRepo": "chronicle-reports",
         "RemoteUsername": "posit-dev",
         "RemoteRef": "dev",
-        "RemoteSha": "2c25b4f846e0bcc44690f8f91801b3b28a3a6cff",
+        "RemoteSha": "39c8c23f3c0a2c8aff553d2e1f2eb60078e67fcd",
         "GithubRepo": "chronicle-reports",
         "GithubUsername": "posit-dev",
         "GithubRef": "dev",
-        "GithubSHA1": "2c25b4f846e0bcc44690f8f91801b3b28a3a6cff",
+        "GithubSHA1": "39c8c23f3c0a2c8aff553d2e1f2eb60078e67fcd",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-09 17:57:38 UTC; root",
+        "Packaged": "2026-06-10 13:10:29 UTC; root",
         "Author": "Mark Tucker [aut, cre],\n  Matt Urbina [aut],\n  Posit Software, PBC [cph, fnd] (03wc8by49)",
         "Maintainer": "Mark Tucker <mark.tucker@posit.co>",
-        "Built": "R 4.1.3; ; 2026-06-09 17:57:39 UTC; unix"
+        "Built": "R 4.1.3; ; 2026-06-10 13:10:29 UTC; unix"
       }
     },
     "cli": {
@@ -568,7 +568,7 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-06 14:40:12 UTC",
-        "Built": "R 4.1.3; ; 2026-06-09 17:46:42 UTC; unix"
+        "Built": "R 4.1.3; ; 2026-06-09 18:25:22 UTC; unix"
       }
     },
     "crosstalk": {
@@ -651,7 +651,7 @@
         "Maintainer": "Tyson Barrett <t.barrett88@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-06 05:10:20 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:47:46 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:26:29 UTC; unix"
       }
     },
     "digest": {
@@ -1092,7 +1092,7 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2026-03-18 06:12:59 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:48:32 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:27:17 UTC; unix"
       }
     },
     "httr": {
@@ -1151,7 +1151,7 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-12-07 06:10:07 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:48:16 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:27:00 UTC; unix"
       }
     },
     "jquerylib": {
@@ -1287,7 +1287,7 @@
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2026-03-05 07:50:02 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:46:43 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:25:23 UTC; unix"
       }
     },
     "lazyeval": {
@@ -1483,7 +1483,7 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-14 14:50:14 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:38:09 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:21:36 UTC; unix"
       }
     },
     "otel": {
@@ -1722,7 +1722,7 @@
         "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-16 21:50:15 UTC",
-        "Built": "R 4.1.3; ; 2026-06-09 17:37:59 UTC; unix"
+        "Built": "R 4.1.3; ; 2026-06-09 18:21:25 UTC; unix"
       }
     },
     "rlang": {
@@ -2053,10 +2053,10 @@
         "GithubRef": "HEAD",
         "GithubSHA1": "c51fe5d0f7fda6dc142fc7212f1727de4d10e664",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-06-09 17:45:45 UTC; root",
+        "Packaged": "2026-06-09 18:24:24 UTC; root",
         "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  Posit Software, PBC [cph, fnd] (03wc8by49)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:45:45 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:24:24 UTC; unix"
       }
     },
     "tidyr": {
@@ -2088,7 +2088,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-12-19 09:20:02 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:57:18 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:36:56 UTC; unix"
       }
     },
     "tidyselect": {
@@ -2145,7 +2145,7 @@
         "Maintainer": "Vitalie Spinu <spinuvit@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2026-01-29 22:20:08 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:48:20 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:27:04 UTC; unix"
       }
     },
     "tinytex": {
@@ -2340,7 +2340,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "RSPM",
         "Date/Publication": "2026-06-01 05:10:03 UTC",
-        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 17:46:40 UTC; unix"
+        "Built": "R 4.1.3; aarch64-unknown-linux-gnu; 2026-06-09 18:25:20 UTC; unix"
       }
     },
     "xtable": {
@@ -2400,10 +2400,10 @@
   },
   "files": {
     "app.R": {
-      "checksum": "a029121a575fcdb3d9f9f57b05b9b999"
+      "checksum": "72b274652a9664e9a936d3cc1ae64b93"
     },
     "renv.lock": {
-      "checksum": "464a9e4c9d2ec946a81da80bdf1d6d60"
+      "checksum": "a3f519e4abf87f44e592b24ba8e4f7e3"
     }
   },
   "users": null

--- a/inst/apps/workbench/renv.lock
+++ b/inst/apps/workbench/renv.lock
@@ -576,7 +576,7 @@
       "RemoteRepo": "chronicle-reports",
       "RemoteUsername": "posit-dev",
       "RemoteRef": "dev",
-      "RemoteSha": "2c25b4f846e0bcc44690f8f91801b3b28a3a6cff",
+      "RemoteSha": "39c8c23f3c0a2c8aff553d2e1f2eb60078e67fcd",
       "NeedsCompilation": "no",
       "Author": "Mark Tucker [aut, cre], Matt Urbina [aut], Posit Software, PBC [cph, fnd] (03wc8by49)",
       "Maintainer": "Mark Tucker <mark.tucker@posit.co>"

--- a/manifests.R
+++ b/manifests.R
@@ -3,11 +3,16 @@
 # (avoids CRAN<->RSPM changes).
 options(repos = c(CRAN = Sys.getenv("CRAN")))
 
-app_dirs <- c('inst/apps/connect', 'inst/apps/workbench')
+# Derive R version requirement from the running R version (set by the
+# Dockerfile FROM image), so changing the base image is the only edit needed.
+r_minor <- strsplit(R.version$minor, "\\.")[[1]][1]
+r_requires <- paste0(">=", R.version$major, ".", r_minor, ".0")
+
+app_dirs <- c("inst/apps/connect", "inst/apps/workbench")
 
 for (app_dir in app_dirs) {
-  message('Processing: ', app_dir)
-  manifest_path <- file.path(app_dir, 'manifest.json')
+  message("Processing: ", app_dir)
+  manifest_path <- file.path(app_dir, "manifest.json")
   ext_meta <- NULL
   if (file.exists(manifest_path)) {
     old <- jsonlite::fromJSON(manifest_path, simplifyVector = FALSE)
@@ -15,16 +20,20 @@ for (app_dir in app_dirs) {
   }
   renv::snapshot(project = app_dir, prompt = FALSE, force = TRUE)
   rsconnect::writeManifest(appDir = app_dir)
+
+  # Post-process the manifest
+  manifest <- jsonlite::fromJSON(manifest_path, simplifyVector = FALSE)
   if (!is.null(ext_meta)) {
-    manifest <- jsonlite::fromJSON(manifest_path, simplifyVector = FALSE)
     manifest <- c(list(extension = ext_meta), manifest)
-    jsonlite::write_json(
-      manifest,
-      manifest_path,
-      auto_unbox = TRUE,
-      pretty = TRUE,
-      null = "null"
-    )
-    message('Restored extension metadata for: ', app_dir)
+    message("Restored extension metadata for: ", app_dir)
   }
+  manifest$environment$r$requires <- r_requires
+  message("Set R version requirement to ", r_requires, " for: ", app_dir)
+  jsonlite::write_json(
+    manifest,
+    manifest_path,
+    auto_unbox = TRUE,
+    pretty = TRUE,
+    null = "null"
+  )
 }


### PR DESCRIPTION
Automate the process of changing the manifest to use `>=` for the R version. Also, use the runtime version of R for determining the R version to put into the manifest. This makes it so the R version is controlled by the FROM image in `Dockerfile.manifests` (one line to change when we need to update/upgrade).

Also regenerated the manifests to verify everything.