### PR TITLE
Fix Workbench Session Sample Data

### DIFF
--- a/R/sample-data.R
+++ b/R/sample-data.R
@@ -1251,7 +1251,6 @@ sample_wb_session_starts_internal <- function() {
         median_ms <- as.integer(round(
           type_median_ms[[st]] * runif(1, 0.85, 1.15)
         ))
-        # With a single observation, every quantile collapses to that value.
         p95_ms <- if (sessions_started <= 1L) {
           median_ms
         } else {
@@ -1316,7 +1315,6 @@ sample_wb_session_starts_user_internal <- function() {
         median_ms <- as.integer(round(
           type_median_ms[[st]] * runif(1, 0.8, 1.2)
         ))
-        # With a single observation, every quantile collapses to that value.
         p95_ms <- if (sessions_started <= 1L) {
           median_ms
         } else {

--- a/R/sample-data.R
+++ b/R/sample-data.R
@@ -1251,7 +1251,12 @@ sample_wb_session_starts_internal <- function() {
         median_ms <- as.integer(round(
           type_median_ms[[st]] * runif(1, 0.85, 1.15)
         ))
-        p95_ms <- as.integer(round(median_ms * runif(1, 1.8, 2.6)))
+        # With a single observation, every quantile collapses to that value.
+        p95_ms <- if (sessions_started <= 1L) {
+          median_ms
+        } else {
+          as.integer(round(median_ms * runif(1, 1.8, 2.6)))
+        }
 
         rows[[length(rows) + 1]] <- data.frame(
           environment = env,
@@ -1311,7 +1316,12 @@ sample_wb_session_starts_user_internal <- function() {
         median_ms <- as.integer(round(
           type_median_ms[[st]] * runif(1, 0.8, 1.2)
         ))
-        p95_ms <- as.integer(round(median_ms * runif(1, 1.5, 2.5)))
+        # With a single observation, every quantile collapses to that value.
+        p95_ms <- if (sessions_started <= 1L) {
+          median_ms
+        } else {
+          as.integer(round(median_ms * runif(1, 1.5, 2.5)))
+        }
 
         rows[[length(rows) + 1]] <- data.frame(
           environment = user_envs[u],

--- a/tests/testthat/test_chronicle_data.R
+++ b/tests/testthat/test_chronicle_data.R
@@ -114,6 +114,14 @@ test_that("chronicle_data loads workbench session start totals by user", {
   expect_true(all(
     collected$p95_startup_duration_ms >= collected$median_startup_duration_ms
   ))
+  # With a single session, p95 must equal median.
+  single_session <- collected[collected$sessions_started == 1L, ]
+  if (nrow(single_session) > 0) {
+    expect_equal(
+      single_session$p95_startup_duration_ms,
+      single_session$median_startup_duration_ms
+    )
+  }
   # 12 sample users
   expect_equal(length(unique(collected$user_guid)), 12)
 })


### PR DESCRIPTION
Fixes a bug where P95 was incorrectly calculated when only 1 session existed