### PR TITLE
Session Duration Reports

### DIFF
--- a/R/sample-data.R
+++ b/R/sample-data.R
@@ -949,93 +949,108 @@ sample_workbench_user_list_internal <- function() {
   )
 }
 
+#' Aggregate the master session table into daily startup totals, optionally
+#' per user. Counts and percentiles are computed from the same session-level
+#' rows that back workbench/session_duration, so the datasets agree exactly.
+#' @noRd
+derive_wb_session_starts_internal <- function(master, by_user = FALSE) {
+  keys <- c(
+    "environment",
+    if (by_user) c("user_guid", "username"),
+    "session_type",
+    "date"
+  )
+
+  groups <- split(
+    master,
+    do.call(interaction, c(master[keys], drop = TRUE))
+  )
+  rows <- lapply(groups, function(g) {
+    out <- g[1, keys, drop = FALSE]
+    out$sessions_started <- nrow(g)
+    out$median_startup_duration_ms <- as.integer(round(
+      stats::median(g$startup_duration_ms)
+    ))
+    out$p95_startup_duration_ms <- as.integer(round(
+      stats::quantile(g$startup_duration_ms, probs = 0.95, names = FALSE)
+    ))
+    out
+  })
+
+  result <- do.call(rbind, rows)
+  rownames(result) <- NULL
+  col_order <- c(
+    setdiff(keys, "date"),
+    "sessions_started",
+    "median_startup_duration_ms",
+    "p95_startup_duration_ms",
+    "date"
+  )
+  result[order(result$date), col_order]
+}
+
 #' @noRd
 sample_wb_session_starts_internal <- function() {
-  dates <- generate_sample_date_sequence(30)
-  session_types <- c("RStudio Pro", "JupyterLab", "VS Code", "Positron")
-  environments <- c("Production", "Development", "Staging")
-
-  set.seed(123)
-
-  # Relative popularity of each session type and a typical startup time (ms).
-  type_volume <- c(
-    "RStudio Pro" = 40,
-    "JupyterLab" = 25,
-    "VS Code" = 18,
-    "Positron" = 12
+  derive_wb_session_starts_internal(
+    sample_wb_sessions_master_internal(),
+    by_user = FALSE
   )
-  type_median_ms <- c(
-    "RStudio Pro" = 3200,
-    "JupyterLab" = 4500,
-    "VS Code" = 2100,
-    "Positron" = 2600
-  )
-  env_scale <- c("Production" = 1.0, "Development" = 0.5, "Staging" = 0.25)
-
-  rows <- list()
-  for (di in seq_along(dates)) {
-    date <- dates[di]
-    weekday_factor <- calculate_weekday_factor(date)
-    for (env in environments) {
-      for (st in session_types) {
-        sessions_started <- max(
-          0L,
-          as.integer(round(
-            type_volume[[st]] *
-              env_scale[[env]] *
-              weekday_factor *
-              runif(1, 0.8, 1.2)
-          ))
-        )
-
-        median_ms <- as.integer(round(
-          type_median_ms[[st]] * runif(1, 0.85, 1.15)
-        ))
-        p95_ms <- if (sessions_started <= 1L) {
-          median_ms
-        } else {
-          as.integer(round(median_ms * runif(1, 1.8, 2.6)))
-        }
-
-        rows[[length(rows) + 1]] <- data.frame(
-          environment = env,
-          session_type = st,
-          sessions_started = sessions_started,
-          median_startup_duration_ms = median_ms,
-          p95_startup_duration_ms = p95_ms,
-          date = date,
-          stringsAsFactors = FALSE
-        )
-      }
-    }
-  }
-
-  do.call(rbind, rows)
 }
 
 #' @noRd
 sample_wb_session_starts_user_internal <- function() {
+  derive_wb_session_starts_internal(
+    sample_wb_sessions_master_internal(),
+    by_user = TRUE
+  )
+}
+
+#' Session-level master table for the Workbench session sample datasets.
+#' session_duration, session_start_totals, and session_start_totals_by_user
+#' are all derived from these rows, so every dataset describes the SAME
+#' sessions — counts and startup percentiles line up exactly across them.
+#'
+#' Everything is drawn per session in one pass per user per day: each user
+#' habitually uses one or two session types and works mostly in a primary
+#' environment, with occasional sessions in the other environments.
+#' @noRd
+sample_wb_sessions_master_internal <- function() {
   dates <- generate_sample_date_sequence(30)
   session_types <- c("RStudio Pro", "JupyterLab", "VS Code", "Positron")
+  environments <- c("Production", "Development", "Staging")
+  env_hosts <- c(
+    "Production" = "wb-prod-01",
+    "Development" = "wb-dev-01",
+    "Staging" = "wb-staging-01"
+  )
 
-  set.seed(321)
+  set.seed(456)
 
-  # Use the same pool as sample_workbench_user_list_internal() so names
-  # in Sessions → By User match the Users → User List.
+  # Same user pool as the Workbench user list so identities line up.
   wb_pool <- generate_workbench_user_pool()
   n_users <- 12
   users <- wb_pool[seq_len(n_users), ]
-  user_envs <- c(
-    rep("Production", 5),
-    rep("Development", 4),
-    rep("Staging", 3)
-  )
-  # Each user habitually uses one or two session types.
+
   user_types <- lapply(seq_len(n_users), function(u) {
     sample(session_types, sample(1:2, 1))
   })
+  user_primary_env <- sample(
+    environments,
+    n_users,
+    replace = TRUE,
+    prob = c(0.5, 0.3, 0.2)
+  )
 
-  type_median_ms <- c(
+  # Typical session length (seconds) per type; durations drawn log-normally
+  # around these so most sessions are short with a long right tail.
+  type_typical_secs <- c(
+    "RStudio Pro" = 3600,
+    "JupyterLab" = 5400,
+    "VS Code" = 2700,
+    "Positron" = 3000
+  )
+  # Typical startup duration (ms) per type; tighter spread than run length.
+  type_startup_ms <- c(
     "RStudio Pro" = 3200,
     "JupyterLab" = 4500,
     "VS Code" = 2100,
@@ -1047,36 +1062,111 @@ sample_wb_session_starts_user_internal <- function() {
     date <- dates[di]
     weekday_factor <- calculate_weekday_factor(date)
     for (u in seq_len(n_users)) {
-      for (st in user_types[[u]]) {
-        sessions_started <- max(
-          1L,
-          as.integer(round(runif(1, 1, 6) * weekday_factor))
-        )
-        median_ms <- as.integer(round(
-          type_median_ms[[st]] * runif(1, 0.8, 1.2)
-        ))
-        p95_ms <- if (sessions_started <= 1L) {
-          median_ms
-        } else {
-          as.integer(round(median_ms * runif(1, 1.5, 2.5)))
-        }
-
-        rows[[length(rows) + 1]] <- data.frame(
-          environment = user_envs[u],
-          user_guid = users$id[u],
-          username = users$username[u],
-          session_type = st,
-          sessions_started = sessions_started,
-          median_startup_duration_ms = median_ms,
-          p95_startup_duration_ms = p95_ms,
-          date = date,
-          stringsAsFactors = FALSE
-        )
+      n_sessions <- as.integer(round(runif(1, 0, 6) * weekday_factor))
+      if (n_sessions == 0L) {
+        next
       }
+
+      # Per-session draws: a habitual session type, and the user's primary
+      # environment three times out of four.
+      st <- sample(user_types[[u]], n_sessions, replace = TRUE)
+      env <- ifelse(
+        runif(n_sessions) < 0.75,
+        user_primary_env[u],
+        sample(environments, n_sessions, replace = TRUE)
+      )
+
+      duration_secs <- pmax(
+        30L,
+        as.integer(round(
+          stats::rlnorm(
+            n_sessions,
+            meanlog = log(type_typical_secs[st]),
+            sdlog = 0.9
+          )
+        ))
+      )
+      startup_ms <- pmax(
+        200L,
+        as.integer(round(
+          stats::rlnorm(
+            n_sessions,
+            meanlog = log(type_startup_ms[st]),
+            sdlog = 0.35
+          )
+        ))
+      )
+      started_at <- as.POSIXct(date, tz = "UTC") +
+        sample(3600 * 8:17, n_sessions, replace = TRUE) +
+        sample(0:3599, n_sessions, replace = TRUE)
+
+      rows[[length(rows) + 1]] <- data.frame(
+        host_name = unname(env_hosts[env]),
+        environment = env,
+        user_guid = users$id[u],
+        username = users$username[u],
+        session_type = st,
+        session_id = sprintf(
+          "%08x",
+          sample.int(.Machine$integer.max, n_sessions)
+        ),
+        duration_seconds = duration_secs,
+        startup_duration_ms = startup_ms,
+        session_started_at = started_at,
+        session_ended_at = started_at + duration_secs,
+        date = date,
+        stringsAsFactors = FALSE
+      )
     }
   }
 
-  do.call(rbind, rows)
+  combined <- do.call(rbind, rows)
+
+  # Assign exit outcomes across the whole dataset rather than per session so
+  # every reason is guaranteed to appear. Reasons match the set Workbench
+  # reports for session exits; counts stay roughly proportional to the
+  # weights below, with a floor so even the rare reasons show up.
+  exit_reasons <- c(
+    "NormalExit",
+    "Killed",
+    "Crashed",
+    "MemoryLimitExceeded",
+    "TooManyOpenFiles",
+    "NotEnoughMemory",
+    "Unknown"
+  )
+  exit_codes <- c(0L, 137L, 139L, 137L, 24L, 12L, NA_integer_)
+  exit_weights <- c(0.80, 0.05, 0.04, 0.04, 0.03, 0.02, 0.02)
+
+  n_sessions <- nrow(combined)
+  min_each <- 5L
+  counts <- pmax(as.integer(round(exit_weights * n_sessions)), min_each)
+  # NormalExit absorbs the rounding/floor difference so counts sum to n.
+  counts[1] <- counts[1] + (n_sessions - sum(counts))
+
+  exit_idx <- sample(rep(seq_along(exit_reasons), times = counts))
+  combined$exit_code <- exit_codes[exit_idx]
+  combined$exit_reason <- exit_reasons[exit_idx]
+
+  combined
+}
+
+#' @noRd
+sample_wb_session_duration_internal <- function() {
+  master <- sample_wb_sessions_master_internal()
+  master[, c(
+    "host_name",
+    "environment",
+    "user_guid",
+    "session_type",
+    "session_id",
+    "duration_seconds",
+    "session_started_at",
+    "session_ended_at",
+    "exit_code",
+    "exit_reason",
+    "date"
+  )]
 }
 
 #' @noRd
@@ -1189,6 +1279,12 @@ create_sample_chronicle_data_internal <- function(base_path) {
     sample_wb_session_starts_user_internal(),
     base_path,
     "workbench/session_start_totals_by_user"
+  )
+
+  write_sample_parquet_internal(
+    sample_wb_session_duration_internal(),
+    base_path,
+    "workbench/session_duration"
   )
 
   base_path

--- a/R/sample-data.R
+++ b/R/sample-data.R
@@ -950,8 +950,10 @@ sample_workbench_user_list_internal <- function() {
 }
 
 #' Aggregate the master session table into daily startup totals, optionally
-#' per user. Counts and percentiles are computed from the same session-level
-#' rows that back workbench/session_duration, so the datasets agree exactly.
+#' per user. Every STARTED session is counted here (including sessions that are
+#' still running), and startup percentiles are computed from the same rows.
+#' workbench/session_duration covers only the sessions that have ENDED, so the
+#' startup totals are always >= the session_duration row counts.
 #' @noRd
 derive_wb_session_starts_internal <- function(master, by_user = FALSE) {
   keys <- c(
@@ -1007,8 +1009,9 @@ sample_wb_session_starts_user_internal <- function() {
 
 #' Session-level master table for the Workbench session sample datasets.
 #' session_duration, session_start_totals, and session_start_totals_by_user
-#' are all derived from these rows, so every dataset describes the SAME
-#' sessions — counts and startup percentiles line up exactly across them.
+#' are all derived from these rows. The start totals count every session that
+#' STARTED; session_duration includes only the subset that has ENDED, so the
+#' started counts are >= the ended counts (some sessions are still running).
 #'
 #' Everything is drawn per session in one pass per user per day: each user
 #' habitually uses one or two session types and works mostly in a primary
@@ -1122,10 +1125,36 @@ sample_wb_sessions_master_internal <- function() {
 
   combined <- do.call(rbind, rows)
 
-  # Assign exit outcomes across the whole dataset rather than per session so
-  # every reason is guaranteed to appear. Reasons match the set Workbench
-  # reports for session exits; counts stay roughly proportional to the
-  # weights below, with a floor so even the rare reasons show up.
+  # Not every started session has ended by the time data is captured. Real
+  # Workbench deployments always have sessions still running, so the number of
+  # sessions STARTED exceeds the number that have ENDED. Recent sessions are
+  # far more likely to still be active, with a small baseline of long-lived
+  # sessions left open on earlier days. Still-running sessions count toward
+  # session_start_totals (they did start) but are excluded from
+  # session_duration (they have no end time, duration, or exit outcome yet).
+  days_from_end <- as.integer(max(dates) - as.Date(combined$date))
+  still_running_prob <- 0.03 + 0.25 * exp(-days_from_end / 2.5)
+  running <- stats::runif(nrow(combined)) < still_running_prob
+
+  # Guarantee at least a handful of still-running sessions (forcing the most
+  # recent ones) so the started > ended gap is always present, even if the
+  # random draw happens to produce none.
+  min_running <- 10L
+  if (sum(running) < min_running) {
+    recent <- order(combined$session_started_at, decreasing = TRUE)
+    running[recent[seq_len(min_running)]] <- TRUE
+  }
+  combined$ended <- !running
+
+  # Running sessions have no recorded end time or final duration yet.
+  combined$session_ended_at[running] <- NA
+  combined$duration_seconds[running] <- NA_integer_
+
+  # Assign exit outcomes to the sessions that have ENDED, across that subset
+  # rather than per session so every reason is guaranteed to appear. Reasons
+  # match the set Workbench reports for session exits; counts stay roughly
+  # proportional to the weights below, with a floor so even the rare reasons
+  # show up.
   exit_reasons <- c(
     "NormalExit",
     "Killed",
@@ -1138,15 +1167,18 @@ sample_wb_sessions_master_internal <- function() {
   exit_codes <- c(0L, 137L, 139L, 137L, 24L, 12L, NA_integer_)
   exit_weights <- c(0.80, 0.05, 0.04, 0.04, 0.03, 0.02, 0.02)
 
-  n_sessions <- nrow(combined)
+  ended_idx <- which(combined$ended)
+  n_ended <- length(ended_idx)
   min_each <- 5L
-  counts <- pmax(as.integer(round(exit_weights * n_sessions)), min_each)
-  # NormalExit absorbs the rounding/floor difference so counts sum to n.
-  counts[1] <- counts[1] + (n_sessions - sum(counts))
+  counts <- pmax(as.integer(round(exit_weights * n_ended)), min_each)
+  # NormalExit absorbs the rounding/floor difference so counts sum to n_ended.
+  counts[1] <- counts[1] + (n_ended - sum(counts))
 
   exit_idx <- sample(rep(seq_along(exit_reasons), times = counts))
-  combined$exit_code <- exit_codes[exit_idx]
-  combined$exit_reason <- exit_reasons[exit_idx]
+  combined$exit_code <- NA_integer_
+  combined$exit_reason <- NA_character_
+  combined$exit_code[ended_idx] <- exit_codes[exit_idx]
+  combined$exit_reason[ended_idx] <- exit_reasons[exit_idx]
 
   combined
 }
@@ -1154,6 +1186,10 @@ sample_wb_sessions_master_internal <- function() {
 #' @noRd
 sample_wb_session_duration_internal <- function() {
   master <- sample_wb_sessions_master_internal()
+  # Only sessions that have ended appear in the duration dataset; still-running
+  # sessions have no end time, duration, or exit outcome yet.
+  master <- master[master$ended, , drop = FALSE]
+  rownames(master) <- NULL
   master[, c(
     "host_name",
     "environment",

--- a/README.md
+++ b/README.md
@@ -156,8 +156,10 @@ A multi-page dashboard for Posit Workbench user analytics:
   - Overview: Licensed users, daily active users, administrators, and super administrators with trend analysis
   - User List: Searchable, Filterable table showing all users with role and activity information
 - **Sessions**:
-  - Overview: Sessions started over time by session type, plus startup-duration trends (median or p95) shown per environment and session type, with environment and metric filters
-  - By User: Searchable, filterable table of session counts and startup durations per user and session type
+  - Overview: Sessions started over time by session type, plus startup-duration trends (median and P95) per session type, with date and environment filters; includes total session hours for the selected range
+  - Duration: Median session-duration trend by session type and a sessions-by-exit-reason breakdown (one bar per session type, colored by exit reason), with date, environment, and session type filters
+  - User Summary: One row per user (with usernames from the latest user list) and session counts pivoted by session type, with date range and environment filters, searchable by username or GUID
+  - User Detail: Single-user drill-down with a searchable user selector (labeled by username) and a date range filter, totals, a Gantt-style session timeline colored by session type, and a table of that user's sessions
 
 Run it: `chronicle_run_app("workbench")`
 
@@ -287,10 +289,11 @@ chronicle.reports::chronicle_list_data(base_path = "/path/to/chronicle/data")
 [4] "connect/content_hits_totals_by_user"
 [5] "connect/user_list"
 [6] "connect/user_totals"
-[7] "workbench/session_start_totals"
-[8] "workbench/session_start_totals_by_user"
-[9] "workbench/user_list"
-[10] "workbench/user_totals"
+[7] "workbench/session_duration"
+[8] "workbench/session_start_totals"
+[9] "workbench/session_start_totals_by_user"
+[10] "workbench/user_list"
+[11] "workbench/user_totals"
 ```
 
 ### Raw Metrics (Advanced)

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ A multi-page dashboard for Posit Workbench user analytics:
   - Overview: Sessions started over time by session type, plus startup-duration trends (median and P95) per session type, with date and environment filters; includes total session hours for the selected range
   - Duration: Median session-duration trend by session type and a sessions-by-exit-reason breakdown (one bar per session type, colored by exit reason), with date, environment, and session type filters
   - User Summary: One row per user (with usernames from the latest user list) and session counts pivoted by session type, with date range and environment filters, searchable by username or GUID
-  - User Detail: Single-user drill-down with a searchable user selector (labeled by username) and a date range filter, totals, a Gantt-style session timeline colored by session type, and a table of that user's sessions
+  - User Detail: Single-user drill-down with a searchable user selector (labeled by username), totals, a Gantt-style session timeline colored by session type, and a table of that user's sessions
 
 Run it: `chronicle_run_app("workbench")`
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -12,8 +12,10 @@ DT
 Filesystem
 fnd
 funder
+Gantt
 ggplot
 github
+GUID
 https
 lintr
 lubridate

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -777,7 +777,7 @@ sessions_overview_ui <- bslib::card(
       theme = bslib::value_box_theme(bg = BRAND_COLORS$BLUE)
     ),
     bslib::value_box(
-      title = "Total Sessions (range)",
+      title = "Total Sessions",
       max_height = "120px",
       value = shiny::textOutput("sessions_total_value"),
       theme = bslib::value_box_theme(bg = BRAND_COLORS$GREEN)

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -771,15 +771,15 @@ sessions_overview_ui <- bslib::card(
   bslib::layout_columns(
     col_widths = c(4, 4, 4),
     bslib::value_box(
-      title = "Sessions Started (latest day)",
+      title = "Total Sessions Started",
       max_height = "120px",
-      value = shiny::textOutput("sessions_latest_value"),
+      value = shiny::textOutput("sessions_started_total_value"),
       theme = bslib::value_box_theme(bg = BRAND_COLORS$BLUE)
     ),
     bslib::value_box(
-      title = "Total Sessions",
+      title = "Total Sessions Ended",
       max_height = "120px",
-      value = shiny::textOutput("sessions_total_value"),
+      value = shiny::textOutput("sessions_ended_total_value"),
       theme = bslib::value_box_theme(bg = BRAND_COLORS$GREEN)
     ),
     bslib::value_box(
@@ -1095,16 +1095,6 @@ sessions_overview_server <- function(
     }
   }
 
-  # Latest-day rows (one per environment/session_type), environment-scoped.
-  latest_sessions_data <- shiny::reactive({
-    data <- sessions_data()
-    if (is.null(data) || nrow(data) == 0) {
-      return(NULL)
-    }
-    max_date <- max(data$date, na.rm = TRUE)
-    data |> dplyr::filter(date == max_date) |> apply_env_filter()
-  })
-
   # Date-range- and environment-scoped rows for the charts and range metrics.
   filtered_sessions_data <- shiny::reactive({
     data <- sessions_data()
@@ -1120,21 +1110,25 @@ sessions_overview_server <- function(
       apply_env_filter()
   })
 
-  # Value boxes (counts only — additive and therefore exact across groups).
-  output$sessions_latest_value <- shiny::renderText({
-    data <- latest_sessions_data()
+  # Total sessions started over the selected range/environment (sums are
+  # additive across groups, so this stays exact).
+  output$sessions_started_total_value <- shiny::renderText({
+    data <- filtered_sessions_data()
     if (is.null(data) || nrow(data) == 0) {
       return("-")
     }
     prettyNum(sum(data$sessions_started, na.rm = TRUE), big.mark = ",")
   })
 
-  output$sessions_total_value <- shiny::renderText({
-    data <- filtered_sessions_data()
-    if (is.null(data) || nrow(data) == 0) {
+  # Total sessions ended over the selected range/environment. Each
+  # session_duration row is one ended session (any exit_reason), so the count
+  # from overview_duration_summary() is the ended-session total.
+  output$sessions_ended_total_value <- shiny::renderText({
+    summary <- overview_duration_summary()
+    if (is.null(summary) || nrow(summary) == 0 || summary$sessions == 0) {
       return("-")
     }
-    prettyNum(sum(data$sessions_started, na.rm = TRUE), big.mark = ",")
+    prettyNum(summary$sessions, big.mark = ",")
   })
 
   # Total session time over the selected range and environment, aggregated in

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -851,6 +851,8 @@ sessions_empty_plot <- function(
 }
 
 # Format a duration in seconds for a value box (e.g. "1.4h", "32m", "45s").
+# Sub-hour values truncate (integer division) rather than round so labels
+# never cross their unit boundary (e.g. 3599s is "59m", never "60m").
 format_duration_secs <- function(secs) {
   if (is.na(secs) || !is.finite(secs)) {
     return("-")
@@ -858,9 +860,9 @@ format_duration_secs <- function(secs) {
   if (secs >= 3600) {
     paste0(formatC(secs / 3600, format = "f", digits = 1), "h")
   } else if (secs >= 60) {
-    paste0(round(secs / 60), "m")
+    paste0(secs %/% 60, "m")
   } else {
-    paste0(round(secs), "s")
+    paste0(floor(secs), "s")
   }
 }
 
@@ -893,8 +895,25 @@ username_lookup <- function(user_list) {
     dplyr::rename(user_guid = "id")
 }
 
+# Collect an Arrow query, returning NULL (with a message) on failure. Used
+# wherever a lazy duration query is materialized, since collect-time errors
+# (e.g. missing data path) surface here rather than when the query is built.
+collect_or_null <- function(query, context) {
+  if (is.null(query)) {
+    return(NULL)
+  }
+  tryCatch(
+    dplyr::collect(query),
+    error = function(e) {
+      message("Error collecting ", context, ": ", e$message)
+      NULL
+    }
+  )
+}
+
 # Filter session-level duration rows by an environment selection ("All",
-# "(Not Set)", or a specific environment). Shared by Overview and Duration.
+# "(Not Set)", or a specific environment). Works on both data frames and
+# lazy Arrow queries. Shared by Overview and Duration.
 filter_duration_env <- function(data, env) {
   if (is.null(env) || env == "All") {
     return(data)
@@ -1118,28 +1137,33 @@ sessions_overview_server <- function(
     prettyNum(sum(data$sessions_started, na.rm = TRUE), big.mark = ",")
   })
 
-  # Session-level duration rows scoped to the overview's date range and
-  # environment filter. Exact statistics — no weighting approximations needed.
-  filtered_overview_duration <- shiny::reactive({
-    data <- duration_data()
-    if (is.null(data) || nrow(data) == 0) {
+  # Total session time over the selected range and environment, aggregated in
+  # Arrow — only a single summary row is collected.
+  overview_duration_summary <- shiny::reactive({
+    ds <- duration_data()
+    if (is.null(ds)) {
       return(NULL)
     }
     shiny::req(input$sessions_overview_date_range)
-    data |>
+    query <- ds |>
       dplyr::filter(
         date >= input$sessions_overview_date_range[1],
         date <= input$sessions_overview_date_range[2]
       ) |>
-      filter_duration_env(input$sessions_overview_environment)
+      filter_duration_env(input$sessions_overview_environment) |>
+      dplyr::summarise(
+        sessions = dplyr::n(),
+        total_duration_seconds = sum(.data$duration_seconds, na.rm = TRUE)
+      )
+    collect_or_null(query, "session duration summary")
   })
 
   output$sessions_total_hours_value <- shiny::renderText({
-    data <- filtered_overview_duration()
-    if (is.null(data) || nrow(data) == 0) {
+    summary <- overview_duration_summary()
+    if (is.null(summary) || nrow(summary) == 0 || summary$sessions == 0) {
       return("-")
     }
-    format_total_hours(sum(data$duration_seconds, na.rm = TRUE))
+    format_total_hours(summary$total_duration_seconds)
   })
 
   # Sessions started over time, one line per session type. Counts are summed
@@ -1354,25 +1378,30 @@ render_session_duration_plot <- function(plot_data, metric_label) {
 }
 
 sessions_duration_server <- function(input, output, session, duration_data) {
-  # Set default date range on first data load only.
+  # Set default date range on first load: min/max dates aggregated in Arrow.
   date_init_done <- shiny::reactiveVal(FALSE)
   shiny::observe({
-    shiny::req(duration_data())
-    if (date_init_done()) {
+    ds <- duration_data()
+    if (date_init_done() || is.null(ds)) {
       return()
     }
 
-    dated_rows <- duration_data() |>
-      dplyr::filter(!is.na(date))
-    if (nrow(dated_rows) == 0) {
+    date_summary <- collect_or_null(
+      ds |>
+        dplyr::filter(!is.na(date)) |>
+        dplyr::summarise(
+          min_date = min(date, na.rm = TRUE),
+          max_date = max(date, na.rm = TRUE)
+        ),
+      "session duration date bounds"
+    )
+    if (
+      is.null(date_summary) ||
+        nrow(date_summary) == 0 ||
+        is.na(date_summary$min_date)
+    ) {
       return()
     }
-
-    date_summary <- dated_rows |>
-      dplyr::summarise(
-        min_date = min(date, na.rm = TRUE),
-        max_date = max(date, na.rm = TRUE)
-      )
 
     initial_start <- initial_date_start(date_summary$min_date)
 
@@ -1386,16 +1415,21 @@ sessions_duration_server <- function(input, output, session, duration_data) {
     date_init_done(TRUE)
   })
 
-  # Populate the environment filter from the loaded data.
+  # Populate the environment filter (distinct values computed in Arrow).
   shiny::observe({
-    data <- duration_data()
-    if (is.null(data) || nrow(data) == 0) {
+    ds <- duration_data()
+    if (is.null(ds)) {
       return()
     }
 
-    env_values <- data |>
-      dplyr::pull(.data$environment) |>
-      unique()
+    env_df <- collect_or_null(
+      ds |> dplyr::distinct(.data$environment),
+      "session duration environments"
+    )
+    if (is.null(env_df) || nrow(env_df) == 0) {
+      return()
+    }
+    env_values <- env_df$environment
 
     has_na <- any(is.na(env_values) | env_values == "" | env_values == " ")
 
@@ -1415,16 +1449,21 @@ sessions_duration_server <- function(input, output, session, duration_data) {
     )
   })
 
-  # Populate the session type filter from the loaded data.
+  # Populate the session type filter (distinct values computed in Arrow).
   shiny::observe({
-    data <- duration_data()
-    if (is.null(data) || nrow(data) == 0) {
+    ds <- duration_data()
+    if (is.null(ds)) {
       return()
     }
 
-    type_values <- data |>
-      dplyr::pull(.data$session_type) |>
-      unique()
+    type_df <- collect_or_null(
+      ds |> dplyr::distinct(.data$session_type),
+      "session duration types"
+    )
+    if (is.null(type_df) || nrow(type_df) == 0) {
+      return()
+    }
+    type_values <- type_df$session_type
     type_values <- sort(type_values[!is.na(type_values)])
 
     shiny::updateSelectInput(
@@ -1434,14 +1473,14 @@ sessions_duration_server <- function(input, output, session, duration_data) {
     )
   })
 
-  # Date-range-, environment-, and type-scoped session rows.
-  filtered_duration_data <- shiny::reactive({
-    data <- duration_data()
-    if (is.null(data) || nrow(data) == 0) {
+  # Date-range-, environment-, and type-scoped LAZY query (not collected).
+  filtered_duration_query <- shiny::reactive({
+    ds <- duration_data()
+    if (is.null(ds)) {
       return(NULL)
     }
     shiny::req(input$sessions_duration_date_range)
-    data <- data |>
+    query <- ds |>
       dplyr::filter(
         date >= input$sessions_duration_date_range[1],
         date <= input$sessions_duration_date_range[2]
@@ -1452,16 +1491,23 @@ sessions_duration_server <- function(input, output, session, duration_data) {
       !is.null(input$sessions_duration_type) &&
         input$sessions_duration_type != "All"
     ) {
-      data <- data |>
+      query <- query |>
         dplyr::filter(.data$session_type == input$sessions_duration_type)
     }
 
-    data
+    query
+  })
+
+  # Collected rows for the median trend chart and value boxes. Exact medians
+  # can't be pushed down to Arrow (only approximate t-digest versions), so
+  # this is the one place the filtered range is materialized.
+  duration_rows <- shiny::reactive({
+    collect_or_null(filtered_duration_query(), "session duration rows")
   })
 
   # Value boxes — exact statistics over session-level rows.
   output$duration_sessions_value <- shiny::renderText({
-    data <- filtered_duration_data()
+    data <- duration_rows()
     if (is.null(data) || nrow(data) == 0) {
       return("-")
     }
@@ -1469,7 +1515,7 @@ sessions_duration_server <- function(input, output, session, duration_data) {
   })
 
   output$duration_median_value <- shiny::renderText({
-    data <- filtered_duration_data()
+    data <- duration_rows()
     if (is.null(data) || nrow(data) == 0) {
       return("-")
     }
@@ -1477,16 +1523,16 @@ sessions_duration_server <- function(input, output, session, duration_data) {
   })
 
   output$duration_hours_value <- shiny::renderText({
-    data <- filtered_duration_data()
+    data <- duration_rows()
     if (is.null(data) || nrow(data) == 0) {
       return("-")
     }
     format_total_hours(sum(data$duration_seconds, na.rm = TRUE))
   })
 
-  # Daily duration statistics (minutes) per session type for the trend charts.
+  # Daily duration statistics (minutes) per session type for the trend chart.
   duration_trend_data <- shiny::reactive({
-    data <- filtered_duration_data()
+    data <- duration_rows()
     if (is.null(data) || nrow(data) == 0) {
       return(NULL)
     }
@@ -1506,19 +1552,28 @@ sessions_duration_server <- function(input, output, session, duration_data) {
       dplyr::arrange(date)
   })
 
-  # Exit reason breakdown (counts by exit reason, split by session type).
+  # Exit reason breakdown — counts aggregated in Arrow; only the small
+  # (exit_reason x session_type) summary is collected.
   duration_exit_data <- shiny::reactive({
-    data <- filtered_duration_data()
-    if (is.null(data) || nrow(data) == 0) {
+    query <- filtered_duration_query()
+    if (is.null(query)) {
       return(NULL)
     }
 
-    data |>
+    counts <- collect_or_null(
+      query |>
+        dplyr::group_by(.data$exit_reason, .data$session_type) |>
+        dplyr::summarise(sessions = dplyr::n(), .groups = "drop"),
+      "exit reason summary"
+    )
+    if (is.null(counts) || nrow(counts) == 0) {
+      return(NULL)
+    }
+
+    counts |>
       dplyr::mutate(
         exit_reason = dplyr::coalesce(.data$exit_reason, "(Unknown)")
       ) |>
-      dplyr::group_by(.data$exit_reason, .data$session_type) |>
-      dplyr::summarise(sessions = dplyr::n(), .groups = "drop") |>
       dplyr::arrange(dplyr::desc(.data$sessions))
   })
 
@@ -1615,7 +1670,7 @@ sessions_duration_server <- function(input, output, session, duration_data) {
     "session_duration_trend_chart"
   )
   output$download_duration_median_raw <- duration_download(
-    filtered_duration_data,
+    duration_rows,
     "session_duration_raw"
   )
   output$download_duration_exit_chart <- duration_download(
@@ -1623,7 +1678,7 @@ sessions_duration_server <- function(input, output, session, duration_data) {
     "session_exit_reason_chart"
   )
   output$download_duration_exit_raw <- duration_download(
-    filtered_duration_data,
+    duration_rows,
     "session_duration_raw"
   )
 }
@@ -1914,21 +1969,11 @@ sessions_by_user_server <- function(
 
 sessions_user_detail_ui <- bslib::card(
   bslib::card_header("Filters"),
-  bslib::layout_columns(
-    col_widths = c(6, 6),
-    shiny::selectizeInput(
-      "user_detail_user",
-      "User:",
-      choices = NULL,
-      options = list(placeholder = "Select a user")
-    ),
-    shiny::dateRangeInput(
-      "user_detail_date_range",
-      "Date Range:",
-      start = NULL,
-      end = NULL,
-      format = "yyyy-mm-dd"
-    )
+  shiny::selectizeInput(
+    "user_detail_user",
+    "User:",
+    choices = NULL,
+    options = list(placeholder = "Select a user")
   ),
   bslib::layout_columns(
     col_widths = c(3, 3, 3, 3),
@@ -1979,15 +2024,23 @@ sessions_user_detail_server <- function(
   user_list_data
 ) {
   # Populate the searchable user dropdown (single user at a time, no "All").
-  # Options are labeled with usernames from the latest user list snapshot so
-  # users can be found by name or GUID.
+  # Distinct users are computed in Arrow; options are labeled with usernames
+  # from the latest user list snapshot so users can be found by name or GUID.
   shiny::observe({
-    data <- duration_data()
-    if (is.null(data) || nrow(data) == 0) {
+    ds <- duration_data()
+    if (is.null(ds)) {
       return()
     }
 
-    users <- sort(unique(data$user_guid))
+    users_df <- collect_or_null(
+      ds |> dplyr::distinct(.data$user_guid),
+      "session users"
+    )
+    if (is.null(users_df) || nrow(users_df) == 0) {
+      return()
+    }
+
+    users <- sort(users_df$user_guid)
     labels <- users
     lookup <- username_lookup(user_list_data())
     if (!is.null(lookup)) {
@@ -2017,49 +2070,23 @@ sessions_user_detail_server <- function(
     )
   })
 
-  # Set default date range on first data load only (full loaded range, like
-  # the other pages; skip on reloads to preserve the user's selection).
-  date_init_done <- shiny::reactiveVal(FALSE)
-  shiny::observe({
-    data <- duration_data()
-    if (date_init_done() || is.null(data) || nrow(data) == 0) {
-      return()
-    }
-
-    dated_rows <- data |> dplyr::filter(!is.na(date))
-    if (nrow(dated_rows) == 0) {
-      return()
-    }
-
-    max_date <- max(dated_rows$date, na.rm = TRUE)
-    min_date <- min(dated_rows$date, na.rm = TRUE)
-
-    shiny::updateDateRangeInput(
-      session,
-      "user_detail_date_range",
-      start = initial_date_start(min_date),
-      end = max_date,
-      max = max_date
-    )
-    date_init_done(TRUE)
-  })
-
-  # Session rows for the selected user within the date range (scopes every
-  # output on this page: value boxes, timeline, and the sessions table),
-  # with username attached.
+  # Session rows for the selected user — the user_guid filter is pushed down
+  # to Arrow, so only that user's rows are ever collected. Scopes every
+  # output on this page: value boxes, timeline, and the sessions table.
   user_sessions <- shiny::reactive({
-    data <- duration_data()
-    if (is.null(data) || nrow(data) == 0) {
+    ds <- duration_data()
+    if (is.null(ds)) {
       return(NULL)
     }
     shiny::req(input$user_detail_user)
-    shiny::req(input$user_detail_date_range)
-    data <- data |>
-      dplyr::filter(
-        .data$user_guid == input$user_detail_user,
-        date >= input$user_detail_date_range[1],
-        date <= input$user_detail_date_range[2]
-      )
+    selected_user <- input$user_detail_user
+    data <- collect_or_null(
+      ds |> dplyr::filter(.data$user_guid == selected_user),
+      "sessions for selected user"
+    )
+    if (is.null(data) || nrow(data) == 0) {
+      return(NULL)
+    }
 
     data <- data |> dplyr::select(-dplyr::any_of("username"))
     lookup <- username_lookup(user_list_data())
@@ -2116,10 +2143,7 @@ sessions_user_detail_server <- function(
   output$user_detail_timeline_plot <- plotly::renderPlotly({
     data <- user_sessions()
     if (is.null(data) || nrow(data) == 0) {
-      return(sessions_empty_plot(
-        "No sessions in selected date range",
-        "Adjust the timeline date range to see more sessions"
-      ))
+      return(sessions_empty_plot("No sessions for selected user", ""))
     }
 
     plot_data <- data |>
@@ -2131,7 +2155,7 @@ sessions_user_detail_server <- function(
       dplyr::mutate(lane = dplyr::row_number())
 
     if (nrow(plot_data) == 0) {
-      return(sessions_empty_plot("No sessions in selected date range", ""))
+      return(sessions_empty_plot("No sessions for selected user", ""))
     }
 
     # format_duration_secs() is scalar; precompute the tooltip labels.
@@ -2429,10 +2453,13 @@ server <- function(input, output, session) {
     }
   })
 
-  # Session-level duration data, shared by Sessions → Overview (summary value
-  # boxes), Sessions → Duration (charts), and Sessions → User Detail. Loaded
-  # deferred when any of those tabs is first visited; the loaded range expands
-  # when a date selector extends beyond it.
+  # Session-level duration data as a LAZY Arrow query (date-range filtered,
+  # never collected here) shared by Sessions → Overview, Duration, and User
+  # Detail. The dataset can be very large in real deployments, so each
+  # consumer pushes the narrowest possible filters/aggregations down to Arrow
+  # and collects only what it needs (e.g. one user's rows, or a grouped
+  # summary). Creation is deferred until one of those tabs is first visited;
+  # the date range expands when a selector extends beyond it.
   should_load_duration <- shiny::reactiveVal(FALSE)
   shiny::observe({
     duration_tabs <- c(
@@ -2461,7 +2488,7 @@ server <- function(input, output, session) {
           range_max <- range$max
           ds <- ds |> dplyr::filter(date >= range_min, date <= range_max)
         }
-        ds |> dplyr::collect()
+        ds
       },
       error = function(e) {
         message("Error loading session duration: ", e$message)
@@ -2473,8 +2500,7 @@ server <- function(input, output, session) {
   shiny::observe({
     overview_val <- input$sessions_overview_date_range
     duration_val <- input$sessions_duration_date_range
-    detail_val <- input$user_detail_date_range
-    date_vals <- c(overview_val, duration_val, detail_val)
+    date_vals <- c(overview_val, duration_val)
     date_vals <- date_vals[!is.na(date_vals)]
     shiny::req(length(date_vals) > 0)
     range <- duration_range()

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -1967,7 +1967,12 @@ sessions_user_detail_ui <- bslib::card(
     "user_detail_user",
     "User:",
     choices = NULL,
-    options = list(placeholder = "Select a user")
+    # Labels show the username only, but the option value is the user GUID, so
+    # searching both fields keeps users findable by GUID as well as name.
+    options = list(
+      placeholder = "Select a user",
+      searchField = c("label", "value")
+    )
   ),
   bslib::layout_columns(
     col_widths = c(3, 3, 3, 3),
@@ -2019,7 +2024,10 @@ sessions_user_detail_server <- function(
 ) {
   # Populate the searchable user dropdown (single user at a time, no "All").
   # Distinct users are computed in Arrow; options are labeled with usernames
-  # from the latest user list snapshot so users can be found by name or GUID.
+  # from the latest user list snapshot. The option value is the GUID and the
+  # input searches both fields, so users can be found by name or GUID even
+  # though only the username is shown. Users with no matching username fall
+  # back to showing their GUID as the label.
   shiny::observe({
     ds <- duration_data()
     if (is.null(ds)) {
@@ -2040,12 +2048,7 @@ sessions_user_detail_server <- function(
     if (!is.null(lookup)) {
       idx <- match(users, lookup$user_guid)
       found <- !is.na(idx)
-      labels[found] <- paste0(
-        lookup$username[idx[found]],
-        " (",
-        users[found],
-        ")"
-      )
+      labels[found] <- lookup$username[idx[found]]
     }
 
     current <- shiny::isolate(input$user_detail_user)

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -66,6 +66,18 @@ SESSION_PALETTE <- c(
   BRAND_COLORS$GRAY
 )
 
+# Wider palette for exit reasons (up to 7 distinct values). Green leads so the
+# most common reason — normally NormalExit — reads as healthy.
+EXIT_PALETTE <- c(
+  BRAND_COLORS$GREEN,
+  BRAND_COLORS$BLUE,
+  BRAND_COLORS$BURGUNDY,
+  "#EE6331",
+  BRAND_COLORS$GRAY,
+  "#419599",
+  "#C0A33E"
+)
+
 # ==============================================
 # Download UI Helper Functions
 # ==============================================
@@ -579,34 +591,9 @@ user_list_ui <- bslib::card(
   )
 )
 
-user_list_server <- function(input, output, session, should_load) {
-  # Load user_list data (snapshot at max_date), deferred until tab is visited
-  user_list_data <- shiny::reactive({
-    shiny::req(should_load())
-    tryCatch(
-      {
-        data <- chronicle_data("workbench/user_list", base_path)
-
-        # Find max_date in Arrow (reads only parquet metadata), then collect
-        # just that partition instead of all historical snapshots
-        max_date_result <- data |>
-          dplyr::summarise(max_date = max(date, na.rm = TRUE)) |>
-          dplyr::collect()
-        if (nrow(max_date_result) == 0) {
-          return(data |> dplyr::head(0) |> dplyr::collect())
-        }
-        max_date <- max_date_result$max_date
-
-        data |>
-          dplyr::filter(date == max_date) |>
-          dplyr::collect()
-      },
-      error = function(e) {
-        message("Error loading user list: ", e$message)
-        NULL
-      }
-    )
-  })
+user_list_server <- function(input, output, session, user_list_data) {
+  # Uses the shared user_list reactive (latest snapshot, loaded in the main
+  # server and shared with the Sessions user tables for username lookups).
 
   # Populate environment filter dynamically
   shiny::observe({
@@ -719,7 +706,10 @@ user_list_server <- function(input, output, session, should_load) {
         options = list(
           pageLength = 25,
           autoWidth = TRUE,
-          scrollX = TRUE
+          scrollX = TRUE,
+          # No built-in DataTables search box — each page provides at most
+          # one search/select control of its own.
+          dom = "lrtip"
         ),
         rownames = FALSE
       )
@@ -779,7 +769,7 @@ sessions_overview_ui <- bslib::card(
     )
   ),
   bslib::layout_columns(
-    col_widths = c(3, 3, 3, 3),
+    col_widths = c(4, 4, 4),
     bslib::value_box(
       title = "Sessions Started (latest day)",
       max_height = "120px",
@@ -793,16 +783,10 @@ sessions_overview_ui <- bslib::card(
       theme = bslib::value_box_theme(bg = BRAND_COLORS$GREEN)
     ),
     bslib::value_box(
-      title = "Median Startup (range avg)",
+      title = "Total Session Hours (range)",
       max_height = "120px",
-      value = shiny::textOutput("sessions_median_value"),
+      value = shiny::textOutput("sessions_total_hours_value"),
       theme = bslib::value_box_theme(bg = BRAND_COLORS$BURGUNDY)
-    ),
-    bslib::value_box(
-      title = "P95 Startup (range avg)",
-      max_height = "120px",
-      value = shiny::textOutput("sessions_p95_value"),
-      theme = bslib::value_box_theme(bg = BRAND_COLORS$GRAY)
     )
   ),
   bslib::card(
@@ -866,35 +850,68 @@ sessions_empty_plot <- function(
     )
 }
 
-# Sessions-weighted mean of a per-group duration column (ms). The dataset stores
-# a daily median/p95 per (environment, session type); those can't be re-medianed
-# exactly, so each group's value is weighted by the sessions it represents —
-# a sound "typical startup" proxy across the selected range and environment.
-sessions_weighted_ms <- function(data, col) {
-  value <- data[[col]]
-  weight <- data$sessions_started
-  ok <- !is.na(value) & is.finite(value) & !is.na(weight) & weight > 0
-  if (!any(ok)) {
-    return(NA_real_)
-  }
-  sum(value[ok] * weight[ok]) / sum(weight[ok])
-}
-
-# Format a duration in milliseconds for a value box (e.g. "2.4s", "850 ms").
-format_startup_ms <- function(ms) {
-  if (is.na(ms) || !is.finite(ms)) {
+# Format a duration in seconds for a value box (e.g. "1.4h", "32m", "45s").
+format_duration_secs <- function(secs) {
+  if (is.na(secs) || !is.finite(secs)) {
     return("-")
   }
-  if (ms >= 1000) {
-    paste0(formatC(ms / 1000, format = "f", digits = 1), "s")
+  if (secs >= 3600) {
+    paste0(formatC(secs / 3600, format = "f", digits = 1), "h")
+  } else if (secs >= 60) {
+    paste0(round(secs / 60), "m")
   } else {
-    paste0(round(ms), " ms")
+    paste0(round(secs), "s")
+  }
+}
+
+# Format total session time (seconds) as hours for a value box.
+format_total_hours <- function(secs) {
+  if (is.na(secs) || !is.finite(secs)) {
+    return("-")
+  }
+  hours <- secs / 3600
+  if (hours >= 100) {
+    prettyNum(round(hours), big.mark = ",")
+  } else {
+    formatC(hours, format = "f", digits = 1)
+  }
+}
+
+# Map user GUIDs to usernames using the latest user list snapshot. Returns a
+# two-column data frame (user_guid, username), or NULL when the user list is
+# unavailable. Mirrors how the Connect app labels content visits.
+username_lookup <- function(user_list) {
+  if (
+    is.null(user_list) ||
+      nrow(user_list) == 0 ||
+      !all(c("id", "username") %in% names(user_list))
+  ) {
+    return(NULL)
+  }
+  user_list |>
+    dplyr::distinct(.data$id, .data$username) |>
+    dplyr::rename(user_guid = "id")
+}
+
+# Filter session-level duration rows by an environment selection ("All",
+# "(Not Set)", or a specific environment). Shared by Overview and Duration.
+filter_duration_env <- function(data, env) {
+  if (is.null(env) || env == "All") {
+    return(data)
+  }
+  if (env == "(Not Set)") {
+    data |>
+      dplyr::filter(
+        is.na(environment) | environment == "" | environment == " "
+      )
+  } else {
+    data |> dplyr::filter(environment == env)
   }
 }
 
 # Build a startup-duration plotly for one metric column (median or p95).
 # Collapses multiple environments into one line per session type via a
-# sessions-weighted average, consistent with the value box calculation.
+# sessions-weighted average (daily percentiles can't be re-medianed exactly).
 render_startup_duration_plot <- function(data, metric_col, metric_label) {
   if (is.null(data) || nrow(data) == 0) {
     return(sessions_empty_plot())
@@ -968,7 +985,13 @@ render_startup_duration_plot <- function(data, metric_col, metric_label) {
     plotly::config(displayModeBar = FALSE)
 }
 
-sessions_overview_server <- function(input, output, session, sessions_data) {
+sessions_overview_server <- function(
+  input,
+  output,
+  session,
+  sessions_data,
+  duration_data
+) {
   # Set default date range on first data load only (skip on reloads to
   # preserve the user's current selection).
   date_init_done <- shiny::reactiveVal(FALSE)
@@ -1095,22 +1118,28 @@ sessions_overview_server <- function(input, output, session, sessions_data) {
     prettyNum(sum(data$sessions_started, na.rm = TRUE), big.mark = ",")
   })
 
-  # Startup-duration boxes: sessions-weighted across the selected range and
-  # environment (daily medians/p95s can't be re-medianed exactly).
-  output$sessions_median_value <- shiny::renderText({
-    data <- filtered_sessions_data()
+  # Session-level duration rows scoped to the overview's date range and
+  # environment filter. Exact statistics — no weighting approximations needed.
+  filtered_overview_duration <- shiny::reactive({
+    data <- duration_data()
     if (is.null(data) || nrow(data) == 0) {
-      return("-")
+      return(NULL)
     }
-    format_startup_ms(sessions_weighted_ms(data, "median_startup_duration_ms"))
+    shiny::req(input$sessions_overview_date_range)
+    data |>
+      dplyr::filter(
+        date >= input$sessions_overview_date_range[1],
+        date <= input$sessions_overview_date_range[2]
+      ) |>
+      filter_duration_env(input$sessions_overview_environment)
   })
 
-  output$sessions_p95_value <- shiny::renderText({
-    data <- filtered_sessions_data()
+  output$sessions_total_hours_value <- shiny::renderText({
+    data <- filtered_overview_duration()
     if (is.null(data) || nrow(data) == 0) {
       return("-")
     }
-    format_startup_ms(sessions_weighted_ms(data, "p95_startup_duration_ms"))
+    format_total_hours(sum(data$duration_seconds, na.rm = TRUE))
   })
 
   # Sessions started over time, one line per session type. Counts are summed
@@ -1198,21 +1227,425 @@ sessions_overview_server <- function(input, output, session, sessions_data) {
 }
 
 # ==============================================
-# Sessions → By User UI/Server
+# Sessions → Duration UI/Server
 # ==============================================
 
-sessions_by_user_ui <- bslib::card(
+sessions_duration_ui <- bslib::card(
   bslib::card_header("Filters"),
   bslib::layout_columns(
-    col_widths = c(4, 4, 4),
+    col_widths = c(6, 3, 3),
+    shiny::dateRangeInput(
+      "sessions_duration_date_range",
+      "Date Range:",
+      start = NULL,
+      end = NULL,
+      format = "yyyy-mm-dd"
+    ),
     shiny::selectInput(
-      "sessions_by_user_environment",
+      "sessions_duration_environment",
       "Environment:",
       choices = c("All")
     ),
     shiny::selectInput(
-      "sessions_by_user_type",
+      "sessions_duration_type",
       "Session Type:",
+      choices = c("All")
+    )
+  ),
+  bslib::layout_columns(
+    col_widths = c(4, 4, 4),
+    bslib::value_box(
+      title = "Sessions Completed (range)",
+      max_height = "120px",
+      value = shiny::textOutput("duration_sessions_value"),
+      theme = bslib::value_box_theme(bg = BRAND_COLORS$BLUE)
+    ),
+    bslib::value_box(
+      title = "Median Duration",
+      max_height = "120px",
+      value = shiny::textOutput("duration_median_value"),
+      theme = bslib::value_box_theme(bg = BRAND_COLORS$GREEN)
+    ),
+    bslib::value_box(
+      title = "Total Session Hours",
+      max_height = "120px",
+      value = shiny::textOutput("duration_hours_value"),
+      theme = bslib::value_box_theme(bg = BRAND_COLORS$BURGUNDY)
+    )
+  ),
+  bslib::card(
+    card_header_with_chart_downloads(
+      "Session Duration Over Time (Median)",
+      "download_duration_median_chart",
+      "download_duration_median_raw"
+    ),
+    shinycssloaders::withSpinner(
+      plotly::plotlyOutput("duration_trend_median_plot")
+    )
+  ),
+  bslib::card(
+    card_header_with_chart_downloads(
+      "Sessions by Exit Reason",
+      "download_duration_exit_chart",
+      "download_duration_exit_raw"
+    ),
+    shinycssloaders::withSpinner(
+      plotly::plotlyOutput("duration_exit_plot")
+    )
+  )
+)
+
+# Build a session-duration trend plotly for one statistic (median or p95).
+# Computed exactly from session-level rows, one line per session type,
+# plotted in minutes for readability.
+render_session_duration_plot <- function(plot_data, metric_label) {
+  if (is.null(plot_data) || nrow(plot_data) == 0) {
+    return(sessions_empty_plot())
+  }
+
+  types <- sort(unique(plot_data$session_type))
+  pal <- stats::setNames(
+    rep(SESSION_PALETTE, length.out = length(types)),
+    types
+  )
+
+  # format_duration_secs() is scalar; precompute the tooltip labels.
+  plot_data$duration_label <- vapply(
+    plot_data$value * 60,
+    format_duration_secs,
+    character(1)
+  )
+
+  p <- suppressWarnings(
+    ggplot2::ggplot(
+      plot_data,
+      ggplot2::aes(x = date, y = .data$value, color = .data$session_type)
+    ) +
+      ggplot2::geom_line(linewidth = 0.5) +
+      ggplot2::geom_point(
+        ggplot2::aes(
+          text = paste0(
+            format(date, "%B %d, %Y"),
+            "<br>",
+            .data$session_type,
+            "<br>",
+            metric_label,
+            ": ",
+            .data$duration_label
+          )
+        ),
+        size = 0.5
+      ) +
+      ggplot2::theme_minimal() +
+      ggplot2::labs(
+        x = "",
+        y = paste0(metric_label, " Session Duration (minutes)"),
+        color = ""
+      ) +
+      ggplot2::scale_color_manual(values = pal)
+  )
+  plotly::ggplotly(p, tooltip = "text") |>
+    plotly::layout(
+      xaxis = list(fixedrange = TRUE),
+      yaxis = list(fixedrange = TRUE),
+      legend = list(orientation = "h", x = 0.5, xanchor = "center")
+    ) |>
+    plotly::config(displayModeBar = FALSE)
+}
+
+sessions_duration_server <- function(input, output, session, duration_data) {
+  # Set default date range on first data load only.
+  date_init_done <- shiny::reactiveVal(FALSE)
+  shiny::observe({
+    shiny::req(duration_data())
+    if (date_init_done()) {
+      return()
+    }
+
+    dated_rows <- duration_data() |>
+      dplyr::filter(!is.na(date))
+    if (nrow(dated_rows) == 0) {
+      return()
+    }
+
+    date_summary <- dated_rows |>
+      dplyr::summarise(
+        min_date = min(date, na.rm = TRUE),
+        max_date = max(date, na.rm = TRUE)
+      )
+
+    initial_start <- initial_date_start(date_summary$min_date)
+
+    shiny::updateDateRangeInput(
+      session,
+      "sessions_duration_date_range",
+      start = initial_start,
+      end = date_summary$max_date,
+      max = date_summary$max_date
+    )
+    date_init_done(TRUE)
+  })
+
+  # Populate the environment filter from the loaded data.
+  shiny::observe({
+    data <- duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return()
+    }
+
+    env_values <- data |>
+      dplyr::pull(.data$environment) |>
+      unique()
+
+    has_na <- any(is.na(env_values) | env_values == "" | env_values == " ")
+
+    env_values <- env_values[
+      !is.na(env_values) & env_values != "" & env_values != " "
+    ] |>
+      sort()
+
+    if (has_na) {
+      env_values <- c(env_values, "(Not Set)")
+    }
+
+    shiny::updateSelectInput(
+      session,
+      "sessions_duration_environment",
+      choices = c("All", env_values)
+    )
+  })
+
+  # Populate the session type filter from the loaded data.
+  shiny::observe({
+    data <- duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return()
+    }
+
+    type_values <- data |>
+      dplyr::pull(.data$session_type) |>
+      unique()
+    type_values <- sort(type_values[!is.na(type_values)])
+
+    shiny::updateSelectInput(
+      session,
+      "sessions_duration_type",
+      choices = c("All", type_values)
+    )
+  })
+
+  # Date-range-, environment-, and type-scoped session rows.
+  filtered_duration_data <- shiny::reactive({
+    data <- duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return(NULL)
+    }
+    shiny::req(input$sessions_duration_date_range)
+    data <- data |>
+      dplyr::filter(
+        date >= input$sessions_duration_date_range[1],
+        date <= input$sessions_duration_date_range[2]
+      ) |>
+      filter_duration_env(input$sessions_duration_environment)
+
+    if (
+      !is.null(input$sessions_duration_type) &&
+        input$sessions_duration_type != "All"
+    ) {
+      data <- data |>
+        dplyr::filter(.data$session_type == input$sessions_duration_type)
+    }
+
+    data
+  })
+
+  # Value boxes — exact statistics over session-level rows.
+  output$duration_sessions_value <- shiny::renderText({
+    data <- filtered_duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return("-")
+    }
+    prettyNum(nrow(data), big.mark = ",")
+  })
+
+  output$duration_median_value <- shiny::renderText({
+    data <- filtered_duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return("-")
+    }
+    format_duration_secs(stats::median(data$duration_seconds, na.rm = TRUE))
+  })
+
+  output$duration_hours_value <- shiny::renderText({
+    data <- filtered_duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return("-")
+    }
+    format_total_hours(sum(data$duration_seconds, na.rm = TRUE))
+  })
+
+  # Daily duration statistics (minutes) per session type for the trend charts.
+  duration_trend_data <- shiny::reactive({
+    data <- filtered_duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return(NULL)
+    }
+
+    data |>
+      dplyr::filter(
+        !is.na(date),
+        !is.na(.data$duration_seconds),
+        is.finite(.data$duration_seconds)
+      ) |>
+      dplyr::group_by(date, .data$session_type) |>
+      dplyr::summarise(
+        sessions = dplyr::n(),
+        median_duration_minutes = stats::median(.data$duration_seconds) / 60,
+        .groups = "drop"
+      ) |>
+      dplyr::arrange(date)
+  })
+
+  # Exit reason breakdown (counts by exit reason, split by session type).
+  duration_exit_data <- shiny::reactive({
+    data <- filtered_duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return(NULL)
+    }
+
+    data |>
+      dplyr::mutate(
+        exit_reason = dplyr::coalesce(.data$exit_reason, "(Unknown)")
+      ) |>
+      dplyr::group_by(.data$exit_reason, .data$session_type) |>
+      dplyr::summarise(sessions = dplyr::n(), .groups = "drop") |>
+      dplyr::arrange(dplyr::desc(.data$sessions))
+  })
+
+  output$duration_trend_median_plot <- plotly::renderPlotly({
+    trend <- duration_trend_data()
+    if (is.null(trend) || nrow(trend) == 0) {
+      return(sessions_empty_plot())
+    }
+    render_session_duration_plot(
+      trend |>
+        dplyr::transmute(
+          date = date,
+          session_type = .data$session_type,
+          value = .data$median_duration_minutes
+        ),
+      "Median"
+    )
+  })
+
+  output$duration_exit_plot <- plotly::renderPlotly({
+    exit_summary <- duration_exit_data()
+    if (is.null(exit_summary) || nrow(exit_summary) == 0) {
+      return(sessions_empty_plot())
+    }
+
+    # Color by exit reason, most common reason first in the legend.
+    reason_order <- exit_summary |>
+      dplyr::group_by(.data$exit_reason) |>
+      dplyr::summarise(total = sum(.data$sessions), .groups = "drop") |>
+      dplyr::arrange(dplyr::desc(.data$total)) |>
+      dplyr::pull(.data$exit_reason)
+
+    plot_data <- exit_summary |>
+      dplyr::mutate(
+        exit_reason = factor(.data$exit_reason, levels = reason_order)
+      )
+
+    pal <- stats::setNames(
+      rep(EXIT_PALETTE, length.out = length(reason_order)),
+      reason_order
+    )
+
+    p <- suppressWarnings(
+      ggplot2::ggplot(
+        plot_data,
+        ggplot2::aes(
+          x = .data$session_type,
+          y = .data$sessions,
+          fill = .data$exit_reason,
+          text = paste0(
+            .data$session_type,
+            "<br>",
+            .data$exit_reason,
+            "<br>",
+            prettyNum(.data$sessions, big.mark = ","),
+            " sessions"
+          )
+        )
+      ) +
+        ggplot2::geom_col() +
+        ggplot2::theme_minimal() +
+        ggplot2::labs(x = "", y = "Sessions", fill = "") +
+        ggplot2::scale_fill_manual(values = pal)
+    )
+
+    plotly::ggplotly(p, tooltip = "text") |>
+      plotly::layout(
+        barmode = "stack",
+        xaxis = list(fixedrange = TRUE),
+        yaxis = list(fixedrange = TRUE),
+        legend = list(orientation = "h", x = 0.5, xanchor = "center")
+      ) |>
+      plotly::config(displayModeBar = FALSE)
+  })
+
+  # Download handlers
+  duration_download <- function(data_fn, suffix) {
+    shiny::downloadHandler(
+      filename = function() {
+        paste0("chronicle_workbench_", suffix, "_", Sys.Date(), ".csv")
+      },
+      content = function(file) {
+        data <- data_fn()
+        if (is.null(data) || nrow(data) == 0) {
+          data <- data.frame()
+        }
+        utils::write.csv(data, file, row.names = FALSE)
+      }
+    )
+  }
+
+  output$download_duration_median_chart <- duration_download(
+    duration_trend_data,
+    "session_duration_trend_chart"
+  )
+  output$download_duration_median_raw <- duration_download(
+    filtered_duration_data,
+    "session_duration_raw"
+  )
+  output$download_duration_exit_chart <- duration_download(
+    duration_exit_data,
+    "session_exit_reason_chart"
+  )
+  output$download_duration_exit_raw <- duration_download(
+    filtered_duration_data,
+    "session_duration_raw"
+  )
+}
+
+# ==============================================
+# Sessions → User Summary UI/Server
+# ==============================================
+
+sessions_by_user_ui <- bslib::card(
+  card_header_with_download("Filters", "download_user_summary"),
+  bslib::layout_columns(
+    col_widths = c(4, 4, 4),
+    shiny::dateRangeInput(
+      "sessions_by_user_date_range",
+      "Date Range:",
+      start = NULL,
+      end = NULL,
+      format = "yyyy-mm-dd"
+    ),
+    shiny::selectInput(
+      "sessions_by_user_environment",
+      "Environment:",
       choices = c("All")
     ),
     shiny::textInput(
@@ -1226,35 +1659,87 @@ sessions_by_user_ui <- bslib::card(
   )
 )
 
-sessions_by_user_server <- function(input, output, session, should_load) {
-  # Load by-user session data (latest snapshot), deferred until tab is visited.
+sessions_by_user_server <- function(
+  input,
+  output,
+  session,
+  should_load,
+  user_list_data
+) {
+  # Daily by-user rows, deferred until the tab is first visited. The loaded
+  # range expands when the date selector extends beyond it (only the
+  # additional partitions are fetched via Arrow partition pruning).
+  by_user_initial_range <- if (!is.null(data_window_cutoff)) {
+    list(min = data_window_cutoff, max = Sys.Date())
+  }
+  by_user_range <- shiny::reactiveVal(by_user_initial_range)
+
   sessions_by_user_data <- shiny::reactive({
     shiny::req(should_load())
+    range <- by_user_range()
     tryCatch(
       {
-        data <- chronicle_data(
+        ds <- chronicle_data(
           "workbench/session_start_totals_by_user",
           base_path
         )
-
-        # Find max_date via Arrow metadata, then collect only that partition.
-        max_date_result <- data |>
-          dplyr::summarise(max_date = max(date, na.rm = TRUE)) |>
-          dplyr::collect()
-        if (nrow(max_date_result) == 0) {
-          return(data |> dplyr::head(0) |> dplyr::collect())
+        if (!is.null(range)) {
+          range_min <- range$min
+          range_max <- range$max
+          ds <- ds |> dplyr::filter(date >= range_min, date <= range_max)
         }
-        max_date <- max_date_result$max_date
-
-        data |>
-          dplyr::filter(date == max_date) |>
-          dplyr::collect()
+        ds |> dplyr::collect()
       },
       error = function(e) {
         message("Error loading session totals by user: ", e$message)
         NULL
       }
     )
+  })
+
+  shiny::observe({
+    date_val <- input$sessions_by_user_date_range
+    shiny::req(date_val)
+    range <- by_user_range()
+    if (is.null(range)) {
+      return()
+    }
+    date_val <- date_val[!is.na(date_val)]
+    if (length(date_val) == 0) {
+      return()
+    }
+    new_min <- min(range$min, date_val)
+    new_max <- max(range$max, date_val)
+    if (new_min < range$min || new_max > range$max) {
+      by_user_range(list(min = new_min, max = new_max))
+    }
+  })
+
+  # Set default date range on first data load only (skip on range expansion
+  # reloads to preserve the user's current selection).
+  date_init_done <- shiny::reactiveVal(FALSE)
+  shiny::observe({
+    data <- sessions_by_user_data()
+    if (date_init_done() || is.null(data) || nrow(data) == 0) {
+      return()
+    }
+
+    dated_rows <- data |> dplyr::filter(!is.na(date))
+    if (nrow(dated_rows) == 0) {
+      return()
+    }
+
+    max_date <- max(dated_rows$date, na.rm = TRUE)
+    min_date <- min(dated_rows$date, na.rm = TRUE)
+
+    shiny::updateDateRangeInput(
+      session,
+      "sessions_by_user_date_range",
+      start = initial_date_start(min_date),
+      end = max_date,
+      max = max_date
+    )
+    date_init_done(TRUE)
   })
 
   # Populate environment filter dynamically
@@ -1286,31 +1771,22 @@ sessions_by_user_server <- function(input, output, session, should_load) {
     )
   })
 
-  # Populate session type filter dynamically
-  shiny::observe({
-    data <- sessions_by_user_data()
-    if (is.null(data) || nrow(data) == 0) {
-      return()
-    }
-
-    type_values <- data |>
-      dplyr::pull(.data$session_type) |>
-      unique()
-    type_values <- sort(type_values[!is.na(type_values)])
-
-    shiny::updateSelectInput(
-      session,
-      "sessions_by_user_type",
-      choices = c("All", type_values)
-    )
-  })
-
-  # Apply filters
-  filtered_sessions_by_user <- shiny::reactive({
+  # Pivoted summary: one row per user, one column per session type, plus a
+  # Total column. The environment filter scopes the counts but environment is
+  # intentionally not shown as a column.
+  user_summary_data <- shiny::reactive({
     data <- sessions_by_user_data()
     if (is.null(data)) {
       return(NULL)
     }
+
+    # Date range filter
+    shiny::req(input$sessions_by_user_date_range)
+    data <- data |>
+      dplyr::filter(
+        date >= input$sessions_by_user_date_range[1],
+        date <= input$sessions_by_user_date_range[2]
+      )
 
     # Environment filter
     if (input$sessions_by_user_environment != "All") {
@@ -1327,25 +1803,56 @@ sessions_by_user_server <- function(input, output, session, should_load) {
       }
     }
 
-    # Session type filter
-    if (input$sessions_by_user_type != "All") {
-      data <- data |>
-        dplyr::filter(.data$session_type == input$sessions_by_user_type)
+    # Attach usernames from the latest user list snapshot (guid -> username).
+    # Any username column already present is dropped so the user list is the
+    # single source of display names.
+    data <- data |> dplyr::select(-dplyr::any_of("username"))
+    lookup <- username_lookup(user_list_data())
+    if (!is.null(lookup)) {
+      data <- data |> dplyr::left_join(lookup, by = "user_guid")
+    } else {
+      data$username <- NA_character_
     }
+    data <- data |>
+      dplyr::mutate(
+        username = ifelse(is.na(.data$username), "(unknown)", .data$username)
+      )
 
-    # Search filter (on user_guid)
+    # Search filter (matches username or GUID)
     if (nzchar(input$sessions_by_user_search)) {
       search_term <- tolower(input$sessions_by_user_search)
       data <- data |>
-        dplyr::filter(grepl(search_term, tolower(.data$user_guid)))
+        dplyr::filter(
+          grepl(search_term, tolower(.data$user_guid)) |
+            grepl(search_term, tolower(.data$username))
+        )
     }
 
-    data
+    if (nrow(data) == 0) {
+      return(data.frame())
+    }
+
+    wide <- data |>
+      dplyr::group_by(.data$username, .data$user_guid, .data$session_type) |>
+      dplyr::summarise(
+        sessions = sum(.data$sessions_started, na.rm = TRUE),
+        .groups = "drop"
+      ) |>
+      tidyr::pivot_wider(
+        names_from = "session_type",
+        values_from = "sessions",
+        values_fill = 0L
+      )
+
+    type_cols <- sort(setdiff(names(wide), c("username", "user_guid")))
+    wide$Total <- rowSums(wide[type_cols])
+    wide[, c("username", "user_guid", type_cols, "Total")] |>
+      dplyr::arrange(dplyr::desc(.data$Total))
   })
 
   # Render table
   output$sessions_by_user_table <- DT::renderDataTable({
-    data <- filtered_sessions_by_user()
+    data <- user_summary_data()
 
     if (is.null(data) || nrow(data) == 0) {
       return(
@@ -1367,7 +1874,334 @@ sessions_by_user_server <- function(input, output, session, should_load) {
     }
 
     data |>
+      # GUID stays in the underlying data (and CSV download) but is not shown.
+      dplyr::select(-"user_guid") |>
+      DT::datatable(
+        colnames = c("Username" = "username"),
+        # Fill the card width (autoWidth would shrink the table to fit its
+        # content, leaving the card mostly empty with few columns).
+        width = "100%",
+        options = list(
+          pageLength = 25,
+          autoWidth = FALSE,
+          scrollX = TRUE,
+          # No built-in DataTables search box — each page provides at most
+          # one search/select control of its own.
+          dom = "lrtip"
+        ),
+        rownames = FALSE
+      )
+  })
+
+  # Download handler for the pivoted summary table
+  output$download_user_summary <- shiny::downloadHandler(
+    filename = function() {
+      paste0("chronicle_workbench_user_summary_", Sys.Date(), ".csv")
+    },
+    content = function(file) {
+      data <- user_summary_data()
+      if (is.null(data) || nrow(data) == 0) {
+        data <- data.frame()
+      }
+      utils::write.csv(data, file, row.names = FALSE)
+    }
+  )
+}
+
+# ==============================================
+# Sessions → User Detail UI/Server
+# ==============================================
+
+sessions_user_detail_ui <- bslib::card(
+  bslib::card_header("Filters"),
+  bslib::layout_columns(
+    col_widths = c(6, 6),
+    shiny::selectizeInput(
+      "user_detail_user",
+      "User:",
+      choices = NULL,
+      options = list(placeholder = "Select a user")
+    ),
+    shiny::dateRangeInput(
+      "user_detail_date_range",
+      "Date Range:",
+      start = NULL,
+      end = NULL,
+      format = "yyyy-mm-dd"
+    )
+  ),
+  bslib::layout_columns(
+    col_widths = c(3, 3, 3, 3),
+    bslib::value_box(
+      title = "Total Sessions",
+      max_height = "120px",
+      value = shiny::textOutput("user_detail_sessions_value"),
+      theme = bslib::value_box_theme(bg = BRAND_COLORS$BLUE)
+    ),
+    bslib::value_box(
+      title = "Total Session Hours",
+      max_height = "120px",
+      value = shiny::textOutput("user_detail_hours_value"),
+      theme = bslib::value_box_theme(bg = BRAND_COLORS$GREEN)
+    ),
+    bslib::value_box(
+      title = "Median Duration",
+      max_height = "120px",
+      value = shiny::textOutput("user_detail_median_value"),
+      theme = bslib::value_box_theme(bg = BRAND_COLORS$BURGUNDY)
+    ),
+    bslib::value_box(
+      title = "Last Active",
+      max_height = "120px",
+      value = shiny::textOutput("user_detail_last_active_value"),
+      theme = bslib::value_box_theme(bg = BRAND_COLORS$GRAY)
+    )
+  ),
+  bslib::card(
+    bslib::card_header("Session Timeline"),
+    shinycssloaders::withSpinner(
+      plotly::plotlyOutput("user_detail_timeline_plot")
+    )
+  ),
+  bslib::card(
+    card_header_with_download("Sessions", "download_user_detail_sessions"),
+    shinycssloaders::withSpinner(
+      DT::dataTableOutput("user_detail_sessions_table")
+    )
+  )
+)
+
+sessions_user_detail_server <- function(
+  input,
+  output,
+  session,
+  duration_data,
+  user_list_data
+) {
+  # Populate the searchable user dropdown (single user at a time, no "All").
+  # Options are labeled with usernames from the latest user list snapshot so
+  # users can be found by name or GUID.
+  shiny::observe({
+    data <- duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return()
+    }
+
+    users <- sort(unique(data$user_guid))
+    labels <- users
+    lookup <- username_lookup(user_list_data())
+    if (!is.null(lookup)) {
+      idx <- match(users, lookup$user_guid)
+      found <- !is.na(idx)
+      labels[found] <- paste0(
+        lookup$username[idx[found]],
+        " (",
+        users[found],
+        ")"
+      )
+    }
+
+    current <- shiny::isolate(input$user_detail_user)
+    selected <- if (!is.null(current) && current %in% users) {
+      current
+    } else {
+      users[1]
+    }
+
+    shiny::updateSelectizeInput(
+      session,
+      "user_detail_user",
+      choices = stats::setNames(users, labels),
+      selected = selected,
+      server = TRUE
+    )
+  })
+
+  # Set default date range on first data load only (full loaded range, like
+  # the other pages; skip on reloads to preserve the user's selection).
+  date_init_done <- shiny::reactiveVal(FALSE)
+  shiny::observe({
+    data <- duration_data()
+    if (date_init_done() || is.null(data) || nrow(data) == 0) {
+      return()
+    }
+
+    dated_rows <- data |> dplyr::filter(!is.na(date))
+    if (nrow(dated_rows) == 0) {
+      return()
+    }
+
+    max_date <- max(dated_rows$date, na.rm = TRUE)
+    min_date <- min(dated_rows$date, na.rm = TRUE)
+
+    shiny::updateDateRangeInput(
+      session,
+      "user_detail_date_range",
+      start = initial_date_start(min_date),
+      end = max_date,
+      max = max_date
+    )
+    date_init_done(TRUE)
+  })
+
+  # Session rows for the selected user within the date range (scopes every
+  # output on this page: value boxes, timeline, and the sessions table),
+  # with username attached.
+  user_sessions <- shiny::reactive({
+    data <- duration_data()
+    if (is.null(data) || nrow(data) == 0) {
+      return(NULL)
+    }
+    shiny::req(input$user_detail_user)
+    shiny::req(input$user_detail_date_range)
+    data <- data |>
+      dplyr::filter(
+        .data$user_guid == input$user_detail_user,
+        date >= input$user_detail_date_range[1],
+        date <= input$user_detail_date_range[2]
+      )
+
+    data <- data |> dplyr::select(-dplyr::any_of("username"))
+    lookup <- username_lookup(user_list_data())
+    if (!is.null(lookup)) {
+      data <- data |> dplyr::left_join(lookup, by = "user_guid")
+    } else {
+      data$username <- NA_character_
+    }
+    data |>
       dplyr::mutate(
+        username = ifelse(is.na(.data$username), "(unknown)", .data$username)
+      )
+  })
+
+  # Totals for the selected user
+  output$user_detail_sessions_value <- shiny::renderText({
+    data <- user_sessions()
+    if (is.null(data) || nrow(data) == 0) {
+      return("-")
+    }
+    prettyNum(nrow(data), big.mark = ",")
+  })
+
+  output$user_detail_hours_value <- shiny::renderText({
+    data <- user_sessions()
+    if (is.null(data) || nrow(data) == 0) {
+      return("-")
+    }
+    format_total_hours(sum(data$duration_seconds, na.rm = TRUE))
+  })
+
+  output$user_detail_median_value <- shiny::renderText({
+    data <- user_sessions()
+    if (is.null(data) || nrow(data) == 0) {
+      return("-")
+    }
+    format_duration_secs(stats::median(data$duration_seconds, na.rm = TRUE))
+  })
+
+  output$user_detail_last_active_value <- shiny::renderText({
+    data <- user_sessions()
+    if (is.null(data) || nrow(data) == 0) {
+      return("-")
+    }
+    last_seen <- suppressWarnings(max(data$session_ended_at, na.rm = TRUE))
+    if (!is.finite(as.numeric(last_seen))) {
+      return("-")
+    }
+    format(last_seen, "%b %d, %Y")
+  })
+
+  # Gantt-style timeline: one horizontal segment per session, ordered by start
+  # time, colored by session type.
+  output$user_detail_timeline_plot <- plotly::renderPlotly({
+    data <- user_sessions()
+    if (is.null(data) || nrow(data) == 0) {
+      return(sessions_empty_plot(
+        "No sessions in selected date range",
+        "Adjust the timeline date range to see more sessions"
+      ))
+    }
+
+    plot_data <- data |>
+      dplyr::filter(
+        !is.na(.data$session_started_at),
+        !is.na(.data$session_ended_at)
+      ) |>
+      dplyr::arrange(.data$session_started_at) |>
+      dplyr::mutate(lane = dplyr::row_number())
+
+    if (nrow(plot_data) == 0) {
+      return(sessions_empty_plot("No sessions in selected date range", ""))
+    }
+
+    # format_duration_secs() is scalar; precompute the tooltip labels.
+    plot_data$duration_label <- vapply(
+      as.numeric(plot_data$duration_seconds),
+      format_duration_secs,
+      character(1)
+    )
+
+    types <- sort(unique(plot_data$session_type))
+    pal <- stats::setNames(
+      rep(SESSION_PALETTE, length.out = length(types)),
+      types
+    )
+
+    p <- suppressWarnings(
+      ggplot2::ggplot(
+        plot_data,
+        ggplot2::aes(
+          x = .data$session_started_at,
+          xend = .data$session_ended_at,
+          y = .data$lane,
+          yend = .data$lane,
+          color = .data$session_type,
+          text = paste0(
+            format(.data$session_started_at, "%B %d, %Y %H:%M"),
+            "<br>",
+            .data$session_type,
+            "<br>Duration: ",
+            .data$duration_label,
+            "<br>Exit: ",
+            .data$exit_reason
+          )
+        )
+      ) +
+        ggplot2::geom_segment(linewidth = 2) +
+        ggplot2::theme_minimal() +
+        ggplot2::labs(x = "", y = "", color = "") +
+        ggplot2::scale_color_manual(values = pal) +
+        ggplot2::theme(
+          axis.text.y = ggplot2::element_blank(),
+          panel.grid.major.y = ggplot2::element_blank(),
+          panel.grid.minor.y = ggplot2::element_blank()
+        )
+    )
+
+    plotly::ggplotly(p, tooltip = "text") |>
+      plotly::layout(
+        xaxis = list(fixedrange = TRUE),
+        yaxis = list(fixedrange = TRUE),
+        legend = list(orientation = "h", x = 0.5, xanchor = "center")
+      ) |>
+      plotly::config(displayModeBar = FALSE)
+  })
+
+  # Session-level table for the selected user.
+  user_detail_table_data <- shiny::reactive({
+    data <- user_sessions()
+    if (is.null(data) || nrow(data) == 0) {
+      return(NULL)
+    }
+
+    data |>
+      dplyr::arrange(dplyr::desc(.data$session_started_at)) |>
+      dplyr::mutate(
+        duration = vapply(
+          as.numeric(.data$duration_seconds),
+          format_duration_secs,
+          character(1)
+        ),
         environment = ifelse(
           is.na(.data$environment) |
             .data$environment == "" |
@@ -1376,32 +2210,78 @@ sessions_by_user_server <- function(input, output, session, should_load) {
           .data$environment
         )
       ) |>
-      dplyr::arrange(dplyr::desc(.data$sessions_started)) |>
       dplyr::select(
-        "user_guid",
+        "username",
+        "session_started_at",
+        "session_ended_at",
         "session_type",
+        "duration",
         "environment",
-        "sessions_started",
-        "median_startup_duration_ms",
-        "p95_startup_duration_ms"
-      ) |>
+        "exit_reason"
+      )
+  })
+
+  output$user_detail_sessions_table <- DT::renderDataTable({
+    data <- user_detail_table_data()
+
+    if (is.null(data) || nrow(data) == 0) {
+      return(
+        DT::datatable(
+          data.frame(
+            " " = "Data not available - Check that Chronicle data exists at the configured path."
+          ),
+          options = list(
+            dom = "t",
+            ordering = FALSE,
+            columnDefs = list(
+              list(className = "dt-center", targets = "_all")
+            )
+          ),
+          rownames = FALSE,
+          colnames = ""
+        )
+      )
+    }
+
+    data |>
       DT::datatable(
         colnames = c(
-          "User" = "user_guid",
+          "Username" = "username",
+          "Started" = "session_started_at",
+          "Ended" = "session_ended_at",
           "Session Type" = "session_type",
+          "Duration" = "duration",
           "Environment" = "environment",
-          "Sessions Started" = "sessions_started",
-          "Median Startup (ms)" = "median_startup_duration_ms",
-          "P95 Startup (ms)" = "p95_startup_duration_ms"
+          "Exit Reason" = "exit_reason"
         ),
+        # Fill the card width (autoWidth would shrink the table to fit its
+        # content, leaving the card mostly empty).
+        width = "100%",
         options = list(
           pageLength = 25,
-          autoWidth = TRUE,
-          scrollX = TRUE
+          autoWidth = FALSE,
+          scrollX = TRUE,
+          # No built-in DataTables search box — each page provides at most
+          # one search/select control of its own.
+          dom = "lrtip"
         ),
         rownames = FALSE
       )
   })
+
+  # Download handler for the user's sessions
+  output$download_user_detail_sessions <- shiny::downloadHandler(
+    filename = function() {
+      paste0("chronicle_workbench_user_detail_", Sys.Date(), ".csv")
+    },
+    content = function(file) {
+      data <- user_sessions()
+      if (is.null(data) || nrow(data) == 0) {
+        data <- data.frame()
+      }
+      utils::write.csv(data, file, row.names = FALSE)
+    }
+  )
 }
 
 # ==============================================
@@ -1429,7 +2309,21 @@ ui <- bslib::page_navbar(
       sessions_overview_ui,
       value = "sessions_overview"
     ),
-    bslib::nav_panel("By User", sessions_by_user_ui, value = "sessions_by_user")
+    bslib::nav_panel(
+      "Duration",
+      sessions_duration_ui,
+      value = "sessions_duration"
+    ),
+    bslib::nav_panel(
+      "User Summary",
+      sessions_by_user_ui,
+      value = "sessions_by_user"
+    ),
+    bslib::nav_panel(
+      "User Detail",
+      sessions_user_detail_ui,
+      value = "sessions_user_detail"
+    )
   )
 )
 
@@ -1438,19 +2332,53 @@ ui <- bslib::page_navbar(
 # ==============================================
 
 server <- function(input, output, session) {
-  # Deferred loading: only load user list data when the tab is first visited
+  # Latest user list snapshot (one date partition), shared by Users → User
+  # List and the Sessions → User Summary / User Detail username lookups.
+  # Deferred until a tab that needs it is first visited.
   should_load_user_list <- shiny::reactiveVal(FALSE)
   shiny::observe({
-    if (!should_load_user_list() && input$main_nav == "user_list") {
+    user_list_tabs <- c(
+      "user_list",
+      "sessions_by_user",
+      "sessions_user_detail"
+    )
+    if (!should_load_user_list() && input$main_nav %in% user_list_tabs) {
       should_load_user_list(TRUE)
     }
+  })
+
+  user_list_data <- shiny::reactive({
+    shiny::req(should_load_user_list())
+    tryCatch(
+      {
+        data <- chronicle_data("workbench/user_list", base_path)
+
+        # Find max_date in Arrow (reads only parquet metadata), then collect
+        # just that partition instead of all historical snapshots
+        max_date_result <- data |>
+          dplyr::summarise(max_date = max(date, na.rm = TRUE)) |>
+          dplyr::collect()
+        if (nrow(max_date_result) == 0) {
+          return(data |> dplyr::head(0) |> dplyr::collect())
+        }
+        max_date <- max_date_result$max_date
+
+        data |>
+          dplyr::filter(date == max_date) |>
+          dplyr::collect()
+      },
+      error = function(e) {
+        message("Error loading user list: ", e$message)
+        NULL
+      }
+    )
   })
 
   # Users → Overview
   users_overview_server(input, output, session)
 
   # Users → User List
-  user_list_server(input, output, session, should_load_user_list)
+  user_list_server(input, output, session, user_list_data)
 
   # Sessions → Overview: load session totals deferred until the tab is visited.
   # The loaded range expands when the date selector extends beyond it (only the
@@ -1501,9 +2429,86 @@ server <- function(input, output, session) {
     }
   })
 
-  sessions_overview_server(input, output, session, sessions_data)
+  # Session-level duration data, shared by Sessions → Overview (summary value
+  # boxes), Sessions → Duration (charts), and Sessions → User Detail. Loaded
+  # deferred when any of those tabs is first visited; the loaded range expands
+  # when a date selector extends beyond it.
+  should_load_duration <- shiny::reactiveVal(FALSE)
+  shiny::observe({
+    duration_tabs <- c(
+      "sessions_overview",
+      "sessions_duration",
+      "sessions_user_detail"
+    )
+    if (!should_load_duration() && input$main_nav %in% duration_tabs) {
+      should_load_duration(TRUE)
+    }
+  })
 
-  # Sessions → By User: load the latest by-user snapshot deferred until visited.
+  duration_initial_range <- if (!is.null(data_window_cutoff)) {
+    list(min = data_window_cutoff, max = Sys.Date())
+  }
+  duration_range <- shiny::reactiveVal(duration_initial_range)
+
+  duration_data <- shiny::reactive({
+    shiny::req(should_load_duration())
+    range <- duration_range()
+    tryCatch(
+      {
+        ds <- chronicle_data("workbench/session_duration", base_path)
+        if (!is.null(range)) {
+          range_min <- range$min
+          range_max <- range$max
+          ds <- ds |> dplyr::filter(date >= range_min, date <= range_max)
+        }
+        ds |> dplyr::collect()
+      },
+      error = function(e) {
+        message("Error loading session duration: ", e$message)
+        NULL
+      }
+    )
+  })
+
+  shiny::observe({
+    overview_val <- input$sessions_overview_date_range
+    duration_val <- input$sessions_duration_date_range
+    detail_val <- input$user_detail_date_range
+    date_vals <- c(overview_val, duration_val, detail_val)
+    date_vals <- date_vals[!is.na(date_vals)]
+    shiny::req(length(date_vals) > 0)
+    range <- duration_range()
+    if (is.null(range)) {
+      return()
+    }
+    new_min <- min(range$min, date_vals)
+    new_max <- max(range$max, date_vals)
+    if (new_min < range$min || new_max > range$max) {
+      duration_range(list(min = new_min, max = new_max))
+    }
+  })
+
+  sessions_overview_server(
+    input,
+    output,
+    session,
+    sessions_data,
+    duration_data
+  )
+
+  # Sessions → Duration
+  sessions_duration_server(input, output, session, duration_data)
+
+  # Sessions → User Detail
+  sessions_user_detail_server(
+    input,
+    output,
+    session,
+    duration_data,
+    user_list_data
+  )
+
+  # Sessions → User Summary: load the by-user totals deferred until visited.
   should_load_sessions_by_user <- shiny::reactiveVal(FALSE)
   shiny::observe({
     if (
@@ -1518,7 +2523,8 @@ server <- function(input, output, session) {
     input,
     output,
     session,
-    should_load_sessions_by_user
+    should_load_sessions_by_user,
+    user_list_data
   )
 }
 

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -1279,7 +1279,7 @@ sessions_duration_ui <- bslib::card(
   bslib::layout_columns(
     col_widths = c(4, 4, 4),
     bslib::value_box(
-      title = "Sessions Completed (range)",
+      title = "Sessions Completed",
       max_height = "120px",
       value = shiny::textOutput("duration_sessions_value"),
       theme = bslib::value_box_theme(bg = BRAND_COLORS$BLUE)

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -783,7 +783,7 @@ sessions_overview_ui <- bslib::card(
       theme = bslib::value_box_theme(bg = BRAND_COLORS$GREEN)
     ),
     bslib::value_box(
-      title = "Total Session Hours (range)",
+      title = "Total Session Hours",
       max_height = "120px",
       value = shiny::textOutput("sessions_total_hours_value"),
       theme = bslib::value_box_theme(bg = BRAND_COLORS$BURGUNDY)

--- a/tests/testthat/test_chronicle_data.R
+++ b/tests/testthat/test_chronicle_data.R
@@ -75,13 +75,15 @@ test_that("chronicle_data loads workbench session start totals", {
   # Data types and sanity checks
   expect_s3_class(collected$date, "Date")
   expect_type(collected$sessions_started, "integer")
-  expect_true(all(collected$sessions_started >= 0))
+  # Groups only exist where sessions occurred (derived from session-level rows)
+  expect_true(all(collected$sessions_started >= 1))
   # p95 should be >= median for every group
   expect_true(all(
     collected$p95_startup_duration_ms >= collected$median_startup_duration_ms
   ))
-  # 30 days x 3 environments x 4 session types
-  expect_equal(nrow(collected), 30 * 3 * 4)
+  # At most one row per (environment, session type) per day over 30 days
+  expect_gt(nrow(collected), 0)
+  expect_lte(nrow(collected), 30 * 3 * 4)
 })
 
 test_that("chronicle_data loads workbench session start totals by user", {
@@ -124,6 +126,94 @@ test_that("chronicle_data loads workbench session start totals by user", {
   }
   # 12 sample users
   expect_equal(length(unique(collected$user_guid)), 12)
+})
+
+test_that("chronicle_data loads workbench session duration", {
+  base_path <- create_sample_chronicle_data()
+  on.exit(unlink(base_path, recursive = TRUE))
+
+  data <- chronicle_data("workbench/session_duration", base_path)
+  collected <- dplyr::collect(data)
+
+  # Expected columns (session-level rows)
+  expect_true(all(
+    c(
+      "host_name",
+      "environment",
+      "user_guid",
+      "session_type",
+      "session_id",
+      "duration_seconds",
+      "session_started_at",
+      "session_ended_at",
+      "exit_code",
+      "exit_reason",
+      "date"
+    ) %in%
+      names(collected)
+  ))
+
+  # Data types and sanity checks
+  expect_s3_class(collected$date, "Date")
+  expect_type(collected$duration_seconds, "integer")
+  expect_true(all(collected$duration_seconds > 0))
+  expect_s3_class(collected$session_started_at, "POSIXct")
+  expect_s3_class(collected$session_ended_at, "POSIXct")
+  # Ended-at must always follow started-at by exactly the duration.
+  expect_equal(
+    as.numeric(
+      collected$session_ended_at - collected$session_started_at,
+      units = "secs"
+    ),
+    as.numeric(collected$duration_seconds)
+  )
+  # Exit reasons drawn from the expected set
+  expect_true(all(
+    collected$exit_reason %in%
+      c(
+        "NormalExit",
+        "Killed",
+        "Crashed",
+        "MemoryLimitExceeded",
+        "TooManyOpenFiles",
+        "NotEnoughMemory",
+        "Unknown"
+      )
+  ))
+  # 12 sample users, matching the by-user dataset
+  expect_equal(length(unique(collected$user_guid)), 12)
+
+  # Every session user resolves to a username via the user list (the apps
+  # join user_guid -> user_list$id for display).
+  user_list <- chronicle_data("workbench/user_list", base_path) |>
+    dplyr::collect()
+  expect_true(all(collected$user_guid %in% user_list$id))
+
+  # All three session datasets are derived from the same master sessions, so
+  # the startup totals must count exactly the sessions in session_duration.
+  totals <- chronicle_data("workbench/session_start_totals", base_path) |>
+    dplyr::collect()
+  expect_equal(sum(totals$sessions_started), nrow(collected))
+
+  by_user <- chronicle_data(
+    "workbench/session_start_totals_by_user",
+    base_path
+  ) |>
+    dplyr::collect()
+  expect_equal(sum(by_user$sessions_started), nrow(collected))
+
+  # Per-user, per-type session counts agree between the two datasets.
+  duration_counts <- table(collected$user_guid, collected$session_type)
+  for (u in rownames(duration_counts)) {
+    for (st in colnames(duration_counts)) {
+      expect_equal(
+        sum(by_user$sessions_started[
+          by_user$user_guid == u & by_user$session_type == st
+        ]),
+        as.integer(duration_counts[u, st])
+      )
+    }
+  }
 })
 
 test_that("chronicle_data supports date filtering", {

--- a/tests/testthat/test_chronicle_data.R
+++ b/tests/testthat/test_chronicle_data.R
@@ -189,24 +189,27 @@ test_that("chronicle_data loads workbench session duration", {
     dplyr::collect()
   expect_true(all(collected$user_guid %in% user_list$id))
 
-  # All three session datasets are derived from the same master sessions, so
-  # the startup totals must count exactly the sessions in session_duration.
+  # All three session datasets are derived from the same master sessions. Every
+  # STARTED session is counted in the startup totals, while session_duration
+  # holds only the sessions that have ENDED, so the started totals must be at
+  # least the session_duration row count -- and strictly greater, because some
+  # sessions are always still running (not all started sessions have ended).
   totals <- chronicle_data("workbench/session_start_totals", base_path) |>
     dplyr::collect()
-  expect_equal(sum(totals$sessions_started), nrow(collected))
+  expect_gt(sum(totals$sessions_started), nrow(collected))
 
   by_user <- chronicle_data(
     "workbench/session_start_totals_by_user",
     base_path
   ) |>
     dplyr::collect()
-  expect_equal(sum(by_user$sessions_started), nrow(collected))
+  expect_gt(sum(by_user$sessions_started), nrow(collected))
 
-  # Per-user, per-type session counts agree between the two datasets.
+  # Per-user, per-type started counts are always >= the ended (duration) counts.
   duration_counts <- table(collected$user_guid, collected$session_type)
   for (u in rownames(duration_counts)) {
     for (st in colnames(duration_counts)) {
-      expect_equal(
+      expect_gte(
         sum(by_user$sessions_started[
           by_user$user_guid == u & by_user$session_type == st
         ]),

--- a/tests/testthat/test_chronicle_list.R
+++ b/tests/testthat/test_chronicle_list.R
@@ -15,6 +15,7 @@ test_that("chronicle_list_data returns available curated metrics", {
   expect_true("workbench/user_list" %in% metrics)
   expect_true("workbench/session_start_totals" %in% metrics)
   expect_true("workbench/session_start_totals_by_user" %in% metrics)
+  expect_true("workbench/session_duration" %in% metrics)
 
   # Check that we have at least 4 metrics
   expect_gte(length(metrics), 4)

--- a/tests/testthat/test_downloads.R
+++ b/tests/testthat/test_downloads.R
@@ -507,13 +507,24 @@ test_that("Workbench: user list download works", {
   on.exit(unlink(base_path, recursive = TRUE))
   env <- source_app_env("workbench", base_path)
 
-  should_load <- shiny::reactive(TRUE)
+  # user_list_server takes the shared user-list snapshot reactive (loaded by
+  # the main server in the app); recreate it here from the sample data.
+  user_list_data <- shiny::reactive({
+    ds <- chronicle_data("workbench/user_list", base_path)
+    max_date <- ds |>
+      dplyr::summarise(max_date = max(date, na.rm = TRUE)) |>
+      dplyr::collect() |>
+      dplyr::pull(max_date)
+    ds |>
+      dplyr::filter(date == max_date) |>
+      dplyr::collect()
+  })
   wb_list_server <- function(input, output, session) {
     env$user_list_server(
       input,
       output,
       session,
-      should_load
+      user_list_data
     )
   }
 


### PR DESCRIPTION
Claude Summary

## Workbench dashboard: session duration reporting

Surfaces the new `workbench/session_duration` curated dataset (one row per
session: duration, start/end timestamps, exit code/reason) across a reworked
Sessions section of the Workbench app.

### App changes (`inst/apps/workbench/app.R`)

**Sessions → Overview**
- Value boxes simplified to one row: Sessions Started (latest day), Total
  Sessions (range), Total Session Hours (range)
- Startup-duration trend charts unchanged

**Sessions → Duration (new)**
- Value boxes: sessions completed, median duration, total session hours
- Median session-duration trend by session type (exact daily stats from
  session-level data)
- Sessions by Exit Reason: one bar per session type, colored by exit reason

**Sessions → User Summary (renamed from By User)**
- Pivoted table: one row per user, one column per session type, plus Total
- Date range + environment filters; search matches username or GUID
- Startup-time columns removed

**Sessions → User Detail (new)**
- Single-user drill-down: searchable user selector + date range filter
- Totals (sessions, hours, median duration, last active), Gantt-style session
  timeline colored by session type, and a sessions table

**Shared**
- Usernames joined from the latest `workbench/user_list` snapshot
  (`user_guid → id`), mirroring the Connect app's content-visit pattern;
  user list now loads once in the main server and is shared across tabs
- Session-duration data loads deferred and is shared by Overview, Duration,
  and User Detail, with date-selector-driven range expansion
- DT tables: built-in search box removed (one search control per page),
  tables fill card width

### Sample data (`R/sample-data.R`)
- New `sample_wb_sessions_master_internal()` is the single source of truth;
  `session_duration`, `session_start_totals`, and
  `session_start_totals_by_user` are all derived from the same sessions, so
  counts and startup percentiles align exactly across datasets

<img width="1922" height="1178" alt="Screenshot 2026-06-12 at 3 00 18 PM" src="https://github.com/user-attachments/assets/a7fb7ee9-71c1-4f39-885e-bc502fefd054" />
<img width="1922" height="1186" alt="Screenshot 2026-06-12 at 3 00 34 PM" src="https://github.com/user-attachments/assets/e50bfc4d-84a7-49d3-aa78-cda7abff2874" />
<img width="1922" height="825" alt="Screenshot 2026-06-12 at 3 00 48 PM" src="https://github.com/user-attachments/assets/10ba683c-b9e6-4dfc-85eb-9f5264021e58" />
<img width="1900" height="1224" alt="Screenshot 2026-06-12 at 3 44 28 PM" src="https://github.com/user-attachments/assets/a2b6542f-52ae-4c59-b964-674722a887c7" />
