### PR TITLE
Update extensions gallery to use main branch

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           extension-name: ${{ matrix.extension }}
           extensions-dir: inst/apps
-          release: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+          release: ${{ github.ref_name == 'main' }}
 
   update-gallery:
     runs-on: ubuntu-latest

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - dev
+      - main
 
 permissions:
   contents: write
@@ -38,7 +38,7 @@ jobs:
         with:
           extension-name: ${{ matrix.extension }}
           extensions-dir: inst/apps
-          release: ${{ github.ref == 'refs/heads/dev' && 'true' || 'false' }}
+          release: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
   update-gallery:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     needs: [extensions]
-    if: always() && github.ref == 'refs/heads/dev'
+    if: always() && github.ref == 'refs/heads/main'
     steps:
       - name: Generate token for GitHub App
         id: generate-token
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: dev
+          ref: main
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action@main

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -45,7 +45,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     needs: [extensions]
-    if: always() && github.ref == 'refs/heads/main'
+    if: always() && github.ref_name == 'main'
     steps:
       - name: Generate token for GitHub App
         id: generate-token


### PR DESCRIPTION
Change the extension gallery update to release from the main branch. ~Also update the extension versions for R.~

This will not release the changes to the gallery on it's own. The next step will be to update the extension version in `dev`. Then when the release PR merges into `main`, the Gallery Extensions will be updated.

<img width="1475" height="546" alt="Screenshot 2026-06-17 at 9 27 19 AM" src="https://github.com/user-attachments/assets/70eab2e8-aebb-4067-942a-8cc0a2e12c0c" />
