### PR TITLE
CI Workflow to Update Manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,8 @@ jobs:
     uses: ./.github/workflows/update-manifests.yml
     secrets: inherit
 
-# The extensions job in extensions.yml will aslo run on pull requests, but only to validate the build.
   extensions:
     needs: [check-r-code, manifests]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     uses: ./.github/workflows/extensions.yml
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,6 @@ jobs:
 
   extensions:
     needs: [check-r-code, manifests]
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'main')
     uses: ./.github/workflows/extensions.yml
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI Workflow
 
 on:
   push:
+    branches: [dev, main]
   pull_request:
   workflow_dispatch:
     inputs:
@@ -32,12 +33,13 @@ jobs:
 
   manifests:
     needs: [check-r-code]
-    if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'main')
+    if: github.event_name == 'push'
     uses: ./.github/workflows/update-manifests.yml
     secrets: inherit
 
+# The extensions job in extensions.yml will aslo run on pull requests, but only to validate the build.
   extensions:
     needs: [check-r-code, manifests]
-    if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'main')
+    if: github.event_name == 'push'
     uses: ./.github/workflows/extensions.yml
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 ---
 name: CI Workflow
+
 on:
   push:
+  pull_request:
   workflow_dispatch:
     inputs:
       ref:
@@ -26,4 +28,16 @@ jobs:
   check-r-code:
     uses: ./.github/workflows/R-CMD-check.yml
     name: Check R code
+    secrets: inherit
+
+  manifests:
+    needs: [check-r-code]
+    if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'main')
+    uses: ./.github/workflows/update-manifests.yml
+    secrets: inherit
+
+  extensions:
+    needs: [check-r-code, manifests]
+    if: github.event_name == 'push' && github.ref_name == 'main'
+    uses: ./.github/workflows/extensions.yml
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,9 @@ jobs:
     uses: ./.github/workflows/update-manifests.yml
     secrets: inherit
 
+# The extensions job in extensions.yml will aslo run on pull requests, but only to validate the build
   extensions:
     needs: [check-r-code, manifests]
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     uses: ./.github/workflows/extensions.yml
     secrets: inherit

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action/build-extension@main

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,10 +1,9 @@
 name: Extensions
 
+# Reusable workflow — invoked by ci.yml on a push to main. Builds the gallery
+# extensions, releases them, and updates the feed. Has no triggers of its own.
 on:
-  pull_request:
-  push:
-    branches:
-      - dev
+  workflow_call:
 
 permissions:
   contents: write
@@ -32,13 +31,14 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action/build-extension@main
         with:
           extension-name: ${{ matrix.extension }}
           extensions-dir: inst/apps
-          release: ${{ github.ref == 'refs/heads/dev' && 'true' || 'false' }}
+          release: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
   update-gallery:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     needs: [extensions]
-    if: always() && github.ref == 'refs/heads/dev'
+    if: always() && github.ref == 'refs/heads/main'
     steps:
       - name: Generate token for GitHub App
         id: generate-token
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: dev
+          ref: ${{ github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action@main

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,6 +1,7 @@
 name: Extensions
 
 on:
+  pull_request:
   workflow_call:
 
 permissions:
@@ -29,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action/build-extension@main

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,10 +1,7 @@
 name: Extensions
 
 on:
-  pull_request:
-  push:
-    branches:
-      - dev
+  workflow_call:
 
 permissions:
   contents: write
@@ -32,6 +29,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action/build-extension@main
@@ -58,7 +56,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: dev
+          ref: ${{ github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action@main

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,7 +1,6 @@
 name: Extensions
 
 on:
-  pull_request:
   workflow_call:
 
 permissions:

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -3,7 +3,10 @@ name: Extensions
 # Reusable workflow — invoked by ci.yml on a push to main. Builds the gallery
 # extensions, releases them, and updates the feed. Has no triggers of its own.
 on:
-  workflow_call:
+  pull_request:
+  push:
+    branches:
+      - dev
 
 permissions:
   contents: write
@@ -31,14 +34,14 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          ref: dev
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action/build-extension@main
         with:
           extension-name: ${{ matrix.extension }}
           extensions-dir: inst/apps
-          release: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+          release: ${{ github.ref == 'refs/heads/dev' && 'true' || 'false' }}
 
   update-gallery:
     runs-on: ubuntu-latest
@@ -46,7 +49,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     needs: [extensions]
-    if: always() && github.ref == 'refs/heads/main'
+    if: always() && github.ref == 'refs/heads/dev'
     steps:
       - name: Generate token for GitHub App
         id: generate-token
@@ -58,7 +61,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          ref: dev
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action@main

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          ref: ${{ github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action/build-extension@main

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,6 +1,7 @@
 name: Extensions
 
 on:
+  pull_request:
   workflow_call:
 
 permissions:

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,7 +1,5 @@
 name: Extensions
 
-# Reusable workflow — invoked by ci.yml on a push to main. Builds the gallery
-# extensions, releases them, and updates the feed. Has no triggers of its own.
 on:
   pull_request:
   push:
@@ -34,7 +32,6 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: dev
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: posit-dev/connect-gallery-action/build-extension@main

--- a/.github/workflows/update-manifests.yml
+++ b/.github/workflows/update-manifests.yml
@@ -1,7 +1,5 @@
 name: Update Manifests
 
-# Reusable workflow — invoked by pipeline.yml. Regenerates the app manifests for
-# the calling branch and commits them back. Has no triggers of its own.
 on:
   workflow_call:
 

--- a/.github/workflows/update-manifests.yml
+++ b/.github/workflows/update-manifests.yml
@@ -33,7 +33,7 @@ jobs:
         id: app-user
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: echo "id=$(gh api "/users/${{ steps.generate-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: echo "id=$(gh api '/users/${{ steps.generate-token.outputs.app-slug }}[bot]' --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push updated manifests
         run: |

--- a/.github/workflows/update-manifests.yml
+++ b/.github/workflows/update-manifests.yml
@@ -23,11 +23,10 @@ jobs:
           ref: ${{ github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Build manifest generator image
-        run: docker build -f Dockerfile.manifests --build-arg GIT_BRANCH=${{ github.ref_name }} -t chronicle-manifests .
+      - uses: extractions/setup-just@v3
 
       - name: Regenerate manifests
-        run: docker run --rm -v "${{ github.workspace }}/inst/apps:/workspace/inst/apps" chronicle-manifests
+        run: just update-manifests ${{ github.ref_name }}
 
       - name: Get GitHub App user id
         id: app-user

--- a/.github/workflows/update-manifests.yml
+++ b/.github/workflows/update-manifests.yml
@@ -1,0 +1,50 @@
+name: Update Manifests
+
+# Reusable workflow — invoked by pipeline.yml. Regenerates the app manifests for
+# the calling branch and commits them back. Has no triggers of its own.
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  update-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token for GitHub App
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.POSIT_CHRONICLE_APP_ID }}
+          private-key: ${{ secrets.POSIT_CHRONICLE_PEM }}
+          permission-contents: write
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Build manifest generator image
+        run: docker build -f Dockerfile.manifests --build-arg GIT_BRANCH=${{ github.ref_name }} -t chronicle-manifests .
+
+      - name: Regenerate manifests
+        run: docker run --rm -v "${{ github.workspace }}/inst/apps:/workspace/inst/apps" chronicle-manifests
+
+      - name: Get GitHub App user id
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: echo "id=$(gh api "/users/${{ steps.generate-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push updated manifests
+        run: |
+          git config user.name '${{ steps.generate-token.outputs.app-slug }}[bot]'
+          git config user.email '${{ steps.app-user.outputs.id }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          if [[ -n "$(git status --porcelain inst/apps)" ]]; then
+            git add inst/apps/*/manifest.json inst/apps/*/renv.lock
+            git commit -m "chore: update app manifests [skip ci]"
+            git push origin HEAD:${{ github.ref_name }}
+          else
+            echo "No manifest changes to commit."
+          fi


### PR DESCRIPTION
Updates Manifests for both `dev` and `main`.

There's still some work to do to confirm the proper versions get applied everywhere (apps and extensions), but this should allow the manifests to auto generate on `dev` and I can iterate from there.