### PR TITLE
get binary R packages

### DIFF
--- a/Dockerfile.manifests
+++ b/Dockerfile.manifests
@@ -1,4 +1,4 @@
-FROM posit/r-base:4.1-noble
+FROM posit/r-base:4.5-noble
 
 RUN apt-get update && apt-get install -y \
   git \
@@ -14,6 +14,9 @@ ENV LANG=en_US.UTF-8
 
 # We use this repo for package installs to use pre-built binaries
 ENV CRAN="https://p3m.dev/cran/__linux__/noble/latest"
+
+## options(repos = c(CRAN = sprintf("https://packagemanager.posit.co/cran/latest/bin/linux/noble-%s/%s", R.version["arch"], substr(getRversion(), 1, 3))))
+
 
 RUN Rscript -e 'install.packages(c("rsconnect", "renv", "remotes", "jsonlite"), repos = Sys.getenv("CRAN"))'
 

--- a/Dockerfile.manifests
+++ b/Dockerfile.manifests
@@ -15,9 +15,6 @@ ENV LANG=en_US.UTF-8
 # We use this repo for package installs to use pre-built binaries
 ENV CRAN="https://p3m.dev/cran/__linux__/noble/latest"
 
-## options(repos = c(CRAN = sprintf("https://packagemanager.posit.co/cran/latest/bin/linux/noble-%s/%s", R.version["arch"], substr(getRversion(), 1, 3))))
-
-
 RUN Rscript -e 'install.packages(c("rsconnect", "renv", "remotes", "jsonlite"), repos = Sys.getenv("CRAN"))'
 
 ARG GIT_BRANCH=main

--- a/manifests.R
+++ b/manifests.R
@@ -3,10 +3,11 @@
 # (avoids CRAN<->RSPM changes).
 options(repos = c(CRAN = Sys.getenv("CRAN")))
 
-# Derive R version requirement from the running R version (set by the
-# Dockerfile FROM image), so changing the base image is the only edit needed.
-r_minor <- strsplit(R.version$minor, "\\.")[[1]][1]
-r_requires <- paste0(">=", R.version$major, ".", r_minor, ".0")
+# Read R version requirement from DESCRIPTION so it stays in sync
+# without hard-coding.
+deps <- read.dcf("DESCRIPTION", fields = "Depends")[[1]]
+r_dep <- trimws(grep("^R\\b", strsplit(deps, ",")[[1]], value = TRUE))
+r_requires <- gsub("R\\s*\\((.*)\\)", "\\1", r_dep) |> trimws()
 
 app_dirs <- c("inst/apps/connect", "inst/apps/workbench")
 


### PR DESCRIPTION
Two changes here:

1) Bump the base image in order to get binary packages from P3M. It appears P3M does not build or maintain binary packages for older R versions.

2) Change how we compute the R version in `manifests.R`. This used to use the running R version (which was determined by the base image). Now it reads the DESCRIPTION file and matches whatever version is in there.