### PR TITLE
Remove `hourly` as a valid `frequency` for raw data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 
 R/.posit/
 .claude-notes/
+# roborev snapshots
+/.roborev/

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Added CSV download buttons to the Connect and Workbench dashboards so users can export the data behind tables and charts.
 * Published the `connect` and `workbench` apps as Posit Connect Gallery extensions for direct installation from the Connect Gallery.
 * Added support for Posit Connect's AWS service-account OAuth integration.
+* Removed support for retrieving `"hourly"` raw metrics. `chronicle_raw_data()` and `chronicle_list_raw_data()` now only accept `frequency = "daily"`.
 
 ## Breaking Changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,11 +6,11 @@
 * Added CSV download buttons to the Connect and Workbench dashboards so users can export the data behind tables and charts.
 * Published the `connect` and `workbench` apps as Posit Connect Gallery extensions for direct installation from the Connect Gallery.
 * Added support for Posit Connect's AWS service-account OAuth integration.
-* Removed support for retrieving `"hourly"` raw metrics. `chronicle_raw_data()` and `chronicle_list_raw_data()` now only accept `frequency = "daily"`.
 
 ## Breaking Changes
 
 * The Connect Usage report now reads the new `connect/content_hits_totals` and `connect/content_hits_totals_by_user` datasets, and the previous visits-based content usage view has been removed. As a result, this version requires data from Chronicle running in Connect and Workbench versions 2026.06.0 and later. Pointing the dashboards at older Chronicle data will cause the affected reports to fail to load.
+* Removed support for retrieving `"hourly"` raw metrics. `chronicle_raw_data()` and `chronicle_list_raw_data()` now only accept `frequency = "daily"`.
 
 # chronicle.reports 0.2.2
 * Added `CHRONICLE_DATA_WINDOW` environment variable to control the amount of data loaded on startup, significantly reducing startup time for large datasets in S3. When not set, all available data is loaded. Date range input changes automatically load additional data so all historical data remains accessible.

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,13 +54,13 @@ chronicle_fs <- function(path) {
 #'
 #' @param base_path Base path to Chronicle data directory
 #' @param metric Name of the metric (e.g., "connect_users")
-#' @param frequency Frequency of data collection ("daily" or "hourly" or "curated")
+#' @param frequency Frequency of data collection ("daily" or "curated")
 #'
 #' @return Character string with the full path to the metric data
 chronicle_path <- function(
   base_path,
   metric = NULL,
-  frequency = c("daily", "hourly", "curated")
+  frequency = c("daily", "curated")
 ) {
   frequency <- match.arg(frequency)
   glue::glue("{base_path}/{frequency}/v2/{metric}/", .null = "")
@@ -97,12 +97,11 @@ chronicle_list_dirs <- function(path) {
 #'
 #' Use raw data only when you need:
 #' - Custom aggregations not available in curated data
-#' - Hourly granularity
 #' - Specific timestamp filtering
 #'
 #' @param metric Name of the metric to retrieve (e.g., "connect_users")
 #' @param base_path Base path to Chronicle data directory
-#' @param frequency Frequency of data collection: "daily" (default) or "hourly"
+#' @param frequency Frequency of data collection: "daily" (default)
 #' @param ymd Optional list with year, month, day for specific date filtering
 #' @param schema Optional Arrow schema for the dataset
 #'
@@ -128,18 +127,17 @@ chronicle_list_dirs <- function(path) {
 #' # Load from production Chronicle data
 #' data <- chronicle_raw_data("connect_users", "/var/lib/posit-chronicle/data")
 #'
-#' # Load hourly data for a specific date
+#' # Load daily data for a specific date
 #' data <- chronicle_raw_data(
 #'   "connect_users",
 #'   "/var/lib/posit-chronicle/data",
-#'   frequency = "hourly",
 #'   ymd = list(year = 2024, month = 12, day = 10)
 #' )
 #' }
 chronicle_raw_data <- function(
   metric,
   base_path = Sys.getenv("CHRONICLE_BASE_PATH", APP_CONFIG$DEFAULT_BASE_PATH),
-  frequency = c("daily", "hourly"),
+  frequency = c("daily"),
   ymd = NULL,
   schema = NULL
 ) {
@@ -266,15 +264,15 @@ chronicle_list_data <- function(
 
 #' List available raw Chronicle metrics
 #'
-#' Lists all available raw metrics available in the Chronicle data
-#' directory at a specified frequency. This is useful for discovering what
+#' Lists all available raw daily metrics available in the Chronicle data
+#' directory. This is useful for discovering what
 #' raw data is available before loading it with [chronicle_raw_data()].
 #'
 #' **Most users should use [chronicle_list_data()] instead**, which lists
 #' curated metrics that are faster and easier to work with.
 #'
 #' @param base_path Base path to Chronicle data directory
-#' @param frequency Frequency of data collection: "daily" (default) or "hourly"
+#' @param frequency Frequency of data collection: "daily" (default)
 #'
 #' @return Character vector of available raw metric names
 #'   (e.g., "connect_users", "workbench_sessions")
@@ -294,19 +292,10 @@ chronicle_list_data <- function(
 #' # List metrics from production Chronicle data
 #' metrics <- chronicle_list_raw_data("/var/lib/posit-chronicle/data", "daily")
 #' print(metrics)
-#'
-#' # List available hourly raw metrics
-#' hourly_metrics <- chronicle_list_raw_data(
-#'   "/var/lib/posit-chronicle/data",
-#'   "hourly"
-#' )
-#'
-#' # Load one of the available metrics
-#' data <- chronicle_raw_data(hourly_metrics[1], "/var/lib/posit-chronicle/data", frequency = "hourly")
 #' }
 chronicle_list_raw_data <- function(
   base_path = Sys.getenv("CHRONICLE_BASE_PATH", APP_CONFIG$DEFAULT_BASE_PATH),
-  frequency = c("daily", "hourly")
+  frequency = c("daily")
 ) {
   frequency <- match.arg(frequency)
   data_path <- chronicle_path(base_path, frequency = frequency)

--- a/man/chronicle_list_raw_data.Rd
+++ b/man/chronicle_list_raw_data.Rd
@@ -6,21 +6,21 @@
 \usage{
 chronicle_list_raw_data(
   base_path = Sys.getenv("CHRONICLE_BASE_PATH", APP_CONFIG$DEFAULT_BASE_PATH),
-  frequency = c("daily", "hourly")
+  frequency = c("daily")
 )
 }
 \arguments{
 \item{base_path}{Base path to Chronicle data directory}
 
-\item{frequency}{Frequency of data collection: "daily" (default) or "hourly"}
+\item{frequency}{Frequency of data collection: "daily" (default)}
 }
 \value{
 Character vector of available raw metric names
 (e.g., "connect_users", "workbench_sessions")
 }
 \description{
-Lists all available raw metrics available in the Chronicle data
-directory at a specified frequency. This is useful for discovering what
+Lists all available raw daily metrics available in the Chronicle data
+directory. This is useful for discovering what
 raw data is available before loading it with \code{\link[=chronicle_raw_data]{chronicle_raw_data()}}.
 }
 \details{
@@ -41,14 +41,5 @@ dplyr::collect(data)
 # List metrics from production Chronicle data
 metrics <- chronicle_list_raw_data("/var/lib/posit-chronicle/data", "daily")
 print(metrics)
-
-# List available hourly raw metrics
-hourly_metrics <- chronicle_list_raw_data(
-  "/var/lib/posit-chronicle/data",
-  "hourly"
-)
-
-# Load one of the available metrics
-data <- chronicle_raw_data(hourly_metrics[1], "/var/lib/posit-chronicle/data", frequency = "hourly")
 }
 }

--- a/man/chronicle_raw_data.Rd
+++ b/man/chronicle_raw_data.Rd
@@ -7,7 +7,7 @@
 chronicle_raw_data(
   metric,
   base_path = Sys.getenv("CHRONICLE_BASE_PATH", APP_CONFIG$DEFAULT_BASE_PATH),
-  frequency = c("daily", "hourly"),
+  frequency = c("daily"),
   ymd = NULL,
   schema = NULL
 )
@@ -17,7 +17,7 @@ chronicle_raw_data(
 
 \item{base_path}{Base path to Chronicle data directory}
 
-\item{frequency}{Frequency of data collection: "daily" (default) or "hourly"}
+\item{frequency}{Frequency of data collection: "daily" (default)}
 
 \item{ymd}{Optional list with year, month, day for specific date filtering}
 
@@ -35,7 +35,6 @@ to work with.
 Use raw data only when you need:
 \itemize{
 \item Custom aggregations not available in curated data
-\item Hourly granularity
 \item Specific timestamp filtering
 }
 }
@@ -58,11 +57,10 @@ head(filtered)
 # Load from production Chronicle data
 data <- chronicle_raw_data("connect_users", "/var/lib/posit-chronicle/data")
 
-# Load hourly data for a specific date
+# Load daily data for a specific date
 data <- chronicle_raw_data(
   "connect_users",
   "/var/lib/posit-chronicle/data",
-  frequency = "hourly",
   ymd = list(year = 2024, month = 12, day = 10)
 )
 }

--- a/tests/testthat/helper-sample-data.R
+++ b/tests/testthat/helper-sample-data.R
@@ -25,7 +25,7 @@ create_sample_chronicle_data <- function(base_path = NULL) {
 #' @param data Data frame with a date column
 #' @param base_path Base path for Chronicle data
 #' @param metric Metric name (e.g., "connect_users")
-#' @param frequency Frequency of data ("daily" or "hourly")
+#' @param frequency Frequency of data ("daily")
 write_raw_parquet_internal <- function(
   data,
   base_path,

--- a/tests/testthat/test_chronicle_list.R
+++ b/tests/testthat/test_chronicle_list.R
@@ -115,17 +115,6 @@ test_that("chronicle_list_raw_data defaults to daily frequency", {
   expect_gte(length(metrics), 1)
 })
 
-test_that("chronicle_list_raw_data handles hourly frequency", {
-  base_path <- create_sample_chronicle_data()
-  on.exit(unlink(base_path, recursive = TRUE))
-
-  # Our sample data doesn't include hourly, but should handle gracefully
-  metrics <- chronicle_list_raw_data(base_path, frequency = "hourly")
-
-  expect_type(metrics, "character")
-  # May be empty since we don't create hourly sample data
-})
-
 test_that("chronicle_list_raw_data validates frequency parameter", {
   base_path <- create_sample_chronicle_data()
   on.exit(unlink(base_path, recursive = TRUE))
@@ -133,7 +122,13 @@ test_that("chronicle_list_raw_data validates frequency parameter", {
   # Invalid frequency should error
   expect_error(
     chronicle_list_raw_data(base_path, frequency = "invalid"),
-    regexp = "should be one of"
+    regexp = "should be"
+  )
+
+  # Hourly data is no longer retrievable
+  expect_error(
+    chronicle_list_raw_data(base_path, frequency = "hourly"),
+    regexp = "should be"
   )
 })
 

--- a/tests/testthat/test_chronicle_raw_data.R
+++ b/tests/testthat/test_chronicle_raw_data.R
@@ -211,7 +211,13 @@ test_that("chronicle_raw_data validates frequency parameter", {
   # Invalid frequency should error
   expect_error(
     chronicle_raw_data("connect_users", base_path, frequency = "invalid"),
-    regexp = "should be one of"
+    regexp = "should be"
+  )
+
+  # Hourly data is no longer retrievable
+  expect_error(
+    chronicle_raw_data("connect_users", base_path, frequency = "hourly"),
+    regexp = "should be"
   )
 })
 


### PR DESCRIPTION
This PR removes `hourly` as a valid option for the `frequency` parameter for `chronicle_raw_data()` and `chronicle_list_raw_data()`. I have left the `frequency` parameter in place, even though it now only has only 1 valid value, for two reasons:

1. Forward-looking, this allows us to add new frequencies (`weekly`, `monthly`, etc) or re-introduce the `hourly` frequency without a breaking change.
2. Backward-looking, this means that this change will be a breaking change only for users who are specifically using the no-longer supported frequency option; users with reports built off of raw data using `daily` frequency will be unaffected.