### PR TITLE
Update gallery extensions (#139)

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -17,25 +17,25 @@
       "description": "Comprehensive Posit Connect usage analytics — tracks licensed users, daily active users, publishers, content metrics, and usage patterns over time.",
       "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/connect",
       "latestVersion": {
-        "version": "1.0.0",
+        "version": "0.0.1",
         "released": "2026-03-24T23:14:09Z",
-        "url": "https://github.com/posit-dev/chronicle-reports/releases/download/connect%40v1.0.0/connect.tar.gz",
-        "minimumConnectVersion": "2026.06.0",
+        "url": "https://github.com/posit-dev/chronicle-reports/releases/download/connect%40v0.0.1/connect.tar.gz",
+        "minimumConnectVersion": "2025.01.0",
         "requiredEnvironment": {
           "r": {
-            "requires": ">=4.1.0"
+            "requires": "~=4.5.0"
           }
         }
       },
       "versions": [
         {
-          "version": "1.0.0",
+          "version": "0.0.1",
           "released": "2026-03-24T23:14:09Z",
-          "url": "https://github.com/posit-dev/chronicle-reports/releases/download/connect%40v1.0.0/connect.tar.gz",
-          "minimumConnectVersion": "2026.06.0",
+          "url": "https://github.com/posit-dev/chronicle-reports/releases/download/connect%40v0.0.1/connect.tar.gz",
+          "minimumConnectVersion": "2025.01.0",
           "requiredEnvironment": {
             "r": {
-              "requires": ">=4.1.0"
+              "requires": "~=4.5.0"
             }
           }
         }
@@ -51,25 +51,25 @@
       "description": "Comprehensive Posit Workbench usage analytics — tracks licensed users, daily active users, session metrics, and admin activity over time.",
       "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/workbench",
       "latestVersion": {
-        "version": "1.0.0",
+        "version": "0.0.1",
         "released": "2026-03-24T23:14:10Z",
-        "url": "https://github.com/posit-dev/chronicle-reports/releases/download/workbench%40v1.0.0/workbench.tar.gz",
-        "minimumConnectVersion": "2026.06.0",
+        "url": "https://github.com/posit-dev/chronicle-reports/releases/download/workbench%40v0.0.1/workbench.tar.gz",
+        "minimumConnectVersion": "2025.01.0",
         "requiredEnvironment": {
           "r": {
-            "requires": ">=4.1.0"
+            "requires": "~=4.5.0"
           }
         }
       },
       "versions": [
         {
-          "version": "1.0.0",
+          "version": "0.0.1",
           "released": "2026-03-24T23:14:10Z",
-          "url": "https://github.com/posit-dev/chronicle-reports/releases/download/workbench%40v1.0.0/workbench.tar.gz",
-          "minimumConnectVersion": "2026.06.0",
+          "url": "https://github.com/posit-dev/chronicle-reports/releases/download/workbench%40v0.0.1/workbench.tar.gz",
+          "minimumConnectVersion": "2025.01.0",
           "requiredEnvironment": {
             "r": {
-              "requires": ">=4.1.0"
+              "requires": "~=4.5.0"
             }
           }
         }

--- a/extensions.json
+++ b/extensions.json
@@ -17,25 +17,25 @@
       "description": "Comprehensive Posit Connect usage analytics — tracks licensed users, daily active users, publishers, content metrics, and usage patterns over time.",
       "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/connect",
       "latestVersion": {
-        "version": "0.0.1",
+        "version": "1.0.0",
         "released": "2026-03-24T23:14:09Z",
-        "url": "https://github.com/posit-dev/chronicle-reports/releases/download/connect%40v0.0.1/connect.tar.gz",
-        "minimumConnectVersion": "2025.01.0",
+        "url": "https://github.com/posit-dev/chronicle-reports/releases/download/connect%40v1.0.0/connect.tar.gz",
+        "minimumConnectVersion": "2026.06.0",
         "requiredEnvironment": {
           "r": {
-            "requires": "~=4.5.0"
+            "requires": ">=4.1.0"
           }
         }
       },
       "versions": [
         {
-          "version": "0.0.1",
+          "version": "1.0.0",
           "released": "2026-03-24T23:14:09Z",
-          "url": "https://github.com/posit-dev/chronicle-reports/releases/download/connect%40v0.0.1/connect.tar.gz",
-          "minimumConnectVersion": "2025.01.0",
+          "url": "https://github.com/posit-dev/chronicle-reports/releases/download/connect%40v1.0.0/connect.tar.gz",
+          "minimumConnectVersion": "2026.06.0",
           "requiredEnvironment": {
             "r": {
-              "requires": "~=4.5.0"
+              "requires": ">=4.1.0"
             }
           }
         }
@@ -51,25 +51,25 @@
       "description": "Comprehensive Posit Workbench usage analytics — tracks licensed users, daily active users, session metrics, and admin activity over time.",
       "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/workbench",
       "latestVersion": {
-        "version": "0.0.1",
+        "version": "1.0.0",
         "released": "2026-03-24T23:14:10Z",
-        "url": "https://github.com/posit-dev/chronicle-reports/releases/download/workbench%40v0.0.1/workbench.tar.gz",
-        "minimumConnectVersion": "2025.01.0",
+        "url": "https://github.com/posit-dev/chronicle-reports/releases/download/workbench%40v1.0.0/workbench.tar.gz",
+        "minimumConnectVersion": "2026.06.0",
         "requiredEnvironment": {
           "r": {
-            "requires": "~=4.5.0"
+            "requires": ">=4.1.0"
           }
         }
       },
       "versions": [
         {
-          "version": "0.0.1",
+          "version": "1.0.0",
           "released": "2026-03-24T23:14:10Z",
-          "url": "https://github.com/posit-dev/chronicle-reports/releases/download/workbench%40v0.0.1/workbench.tar.gz",
-          "minimumConnectVersion": "2025.01.0",
+          "url": "https://github.com/posit-dev/chronicle-reports/releases/download/workbench%40v1.0.0/workbench.tar.gz",
+          "minimumConnectVersion": "2026.06.0",
           "requiredEnvironment": {
             "r": {
-              "requires": "~=4.5.0"
+              "requires": ">=4.1.0"
             }
           }
         }

--- a/inst/apps/connect/manifest.json
+++ b/inst/apps/connect/manifest.json
@@ -8,9 +8,9 @@
     "tags": [
       "Chronicle reports"
     ],
-    "minimumConnectVersion": "2025.01.0",
+    "minimumConnectVersion": "2026.06.0",
     "requiredFeatures": [],
-    "version": "0.0.1"
+    "version": "1.0.0"
   },
   "version": 1,
   "locale": "en_US",

--- a/inst/apps/connect/manifest.json
+++ b/inst/apps/connect/manifest.json
@@ -475,16 +475,16 @@
         "RemoteRepo": "chronicle-reports",
         "RemoteUsername": "posit-dev",
         "RemoteRef": "dev",
-        "RemoteSha": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
+        "RemoteSha": "2796abf30e51de45150a664a6b7d6cebb85f5b90",
         "GithubRepo": "chronicle-reports",
         "GithubUsername": "posit-dev",
         "GithubRef": "dev",
-        "GithubSHA1": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
+        "GithubSHA1": "2796abf30e51de45150a664a6b7d6cebb85f5b90",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-30 16:52:26 UTC; root",
+        "Packaged": "2026-07-01 12:47:43 UTC; root",
         "Author": "Mark Tucker [aut, cre],\n  Matt Urbina [aut],\n  Tim Margheim [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Mark Tucker <mark.tucker@posit.co>",
-        "Built": "R 4.5.3; ; 2026-06-30 16:52:27 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-07-01 12:47:43 UTC; unix"
       }
     },
     "cli": {
@@ -2077,16 +2077,16 @@
         "RemoteRepo": "tibble",
         "RemoteUsername": "tidyverse",
         "RemoteRef": "HEAD",
-        "RemoteSha": "50c178c49fb4a7d1b7bb67bd675ac30b3af33a03",
+        "RemoteSha": "6581b5f249894507133eeb3a990f9c85ac7b2914",
         "GithubRepo": "tibble",
         "GithubUsername": "tidyverse",
         "GithubRef": "HEAD",
-        "GithubSHA1": "50c178c49fb4a7d1b7bb67bd675ac30b3af33a03",
+        "GithubSHA1": "6581b5f249894507133eeb3a990f9c85ac7b2914",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-06-30 16:51:39 UTC; root",
+        "Packaged": "2026-07-01 12:46:58 UTC; root",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Built": "R 4.5.3; x86_64-pc-linux-gnu; 2026-06-30 16:51:40 UTC; unix"
+        "Built": "R 4.5.3; x86_64-pc-linux-gnu; 2026-07-01 12:46:58 UTC; unix"
       }
     },
     "tidyr": {
@@ -2456,7 +2456,7 @@
       "checksum": "b0b3177ac72498f5af3a16666a69320c"
     },
     "renv.lock": {
-      "checksum": "2deb3616a2c2fe3bd945beac1e9777bf"
+      "checksum": "3603b6f4a6b76e7daa8015b9b8e360d9"
     }
   },
   "users": null

--- a/inst/apps/connect/manifest.json
+++ b/inst/apps/connect/manifest.json
@@ -474,17 +474,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "chronicle-reports",
         "RemoteUsername": "posit-dev",
-        "RemoteRef": "main",
-        "RemoteSha": "ffef35926647ba63480b7f07449855654746482e",
+        "RemoteRef": "dev",
+        "RemoteSha": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
         "GithubRepo": "chronicle-reports",
         "GithubUsername": "posit-dev",
-        "GithubRef": "main",
-        "GithubSHA1": "ffef35926647ba63480b7f07449855654746482e",
+        "GithubRef": "dev",
+        "GithubSHA1": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-30 14:46:01 UTC; root",
+        "Packaged": "2026-06-30 16:52:26 UTC; root",
         "Author": "Mark Tucker [aut, cre],\n  Matt Urbina [aut],\n  Tim Margheim [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Mark Tucker <mark.tucker@posit.co>",
-        "Built": "R 4.5.3; ; 2026-06-30 14:46:01 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-06-30 16:52:27 UTC; unix"
       }
     },
     "cli": {
@@ -2083,10 +2083,10 @@
         "GithubRef": "HEAD",
         "GithubSHA1": "50c178c49fb4a7d1b7bb67bd675ac30b3af33a03",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-06-30 14:45:15 UTC; root",
+        "Packaged": "2026-06-30 16:51:39 UTC; root",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Built": "R 4.5.3; x86_64-pc-linux-gnu; 2026-06-30 14:45:16 UTC; unix"
+        "Built": "R 4.5.3; x86_64-pc-linux-gnu; 2026-06-30 16:51:40 UTC; unix"
       }
     },
     "tidyr": {
@@ -2456,7 +2456,7 @@
       "checksum": "b0b3177ac72498f5af3a16666a69320c"
     },
     "renv.lock": {
-      "checksum": "55222040529e65dac7bf5805032bf43c"
+      "checksum": "2deb3616a2c2fe3bd945beac1e9777bf"
     }
   },
   "users": null

--- a/inst/apps/connect/renv.lock
+++ b/inst/apps/connect/renv.lock
@@ -577,7 +577,7 @@
       "RemoteRepo": "chronicle-reports",
       "RemoteUsername": "posit-dev",
       "RemoteRef": "dev",
-      "RemoteSha": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
+      "RemoteSha": "2796abf30e51de45150a664a6b7d6cebb85f5b90",
       "NeedsCompilation": "no",
       "Author": "Mark Tucker [aut, cre], Matt Urbina [aut], Tim Margheim [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Mark Tucker <mark.tucker@posit.co>"
@@ -2784,7 +2784,7 @@
       "RemoteRepo": "tibble",
       "RemoteUsername": "tidyverse",
       "RemoteRef": "HEAD",
-      "RemoteSha": "50c178c49fb4a7d1b7bb67bd675ac30b3af33a03",
+      "RemoteSha": "6581b5f249894507133eeb3a990f9c85ac7b2914",
       "NeedsCompilation": "yes",
       "Author": "Kirill Müller [aut, cre] (ORCID: <https://orcid.org/0000-0002-1416-3412>), Hadley Wickham [aut], Romain Francois [ctb], Jennifer Bryan [ctb], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Kirill Müller <kirill@cynkra.com>"

--- a/inst/apps/connect/renv.lock
+++ b/inst/apps/connect/renv.lock
@@ -576,8 +576,8 @@
       "RemoteHost": "api.github.com",
       "RemoteRepo": "chronicle-reports",
       "RemoteUsername": "posit-dev",
-      "RemoteRef": "main",
-      "RemoteSha": "ffef35926647ba63480b7f07449855654746482e",
+      "RemoteRef": "dev",
+      "RemoteSha": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
       "NeedsCompilation": "no",
       "Author": "Mark Tucker [aut, cre], Matt Urbina [aut], Tim Margheim [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Mark Tucker <mark.tucker@posit.co>"

--- a/inst/apps/workbench/manifest.json
+++ b/inst/apps/workbench/manifest.json
@@ -8,9 +8,9 @@
     "tags": [
       "Chronicle reports"
     ],
-    "minimumConnectVersion": "2025.01.0",
+    "minimumConnectVersion": "2026.06.0",
     "requiredFeatures": [],
-    "version": "0.0.1"
+    "version": "1.0.0"
   },
   "version": 1,
   "locale": "en_US",

--- a/inst/apps/workbench/manifest.json
+++ b/inst/apps/workbench/manifest.json
@@ -474,17 +474,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "chronicle-reports",
         "RemoteUsername": "posit-dev",
-        "RemoteRef": "main",
-        "RemoteSha": "ffef35926647ba63480b7f07449855654746482e",
+        "RemoteRef": "dev",
+        "RemoteSha": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
         "GithubRepo": "chronicle-reports",
         "GithubUsername": "posit-dev",
-        "GithubRef": "main",
-        "GithubSHA1": "ffef35926647ba63480b7f07449855654746482e",
+        "GithubRef": "dev",
+        "GithubSHA1": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-30 14:46:01 UTC; root",
+        "Packaged": "2026-06-30 16:52:26 UTC; root",
         "Author": "Mark Tucker [aut, cre],\n  Matt Urbina [aut],\n  Tim Margheim [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Mark Tucker <mark.tucker@posit.co>",
-        "Built": "R 4.5.3; ; 2026-06-30 14:46:01 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-06-30 16:52:27 UTC; unix"
       }
     },
     "cli": {
@@ -2083,10 +2083,10 @@
         "GithubRef": "HEAD",
         "GithubSHA1": "50c178c49fb4a7d1b7bb67bd675ac30b3af33a03",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-06-30 14:45:15 UTC; root",
+        "Packaged": "2026-06-30 16:51:39 UTC; root",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Built": "R 4.5.3; x86_64-pc-linux-gnu; 2026-06-30 14:45:16 UTC; unix"
+        "Built": "R 4.5.3; x86_64-pc-linux-gnu; 2026-06-30 16:51:40 UTC; unix"
       }
     },
     "tidyr": {
@@ -2456,7 +2456,7 @@
       "checksum": "28e6f4ef31e1647540845455742ba4c8"
     },
     "renv.lock": {
-      "checksum": "55222040529e65dac7bf5805032bf43c"
+      "checksum": "2deb3616a2c2fe3bd945beac1e9777bf"
     }
   },
   "users": null

--- a/inst/apps/workbench/manifest.json
+++ b/inst/apps/workbench/manifest.json
@@ -475,16 +475,16 @@
         "RemoteRepo": "chronicle-reports",
         "RemoteUsername": "posit-dev",
         "RemoteRef": "dev",
-        "RemoteSha": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
+        "RemoteSha": "2796abf30e51de45150a664a6b7d6cebb85f5b90",
         "GithubRepo": "chronicle-reports",
         "GithubUsername": "posit-dev",
         "GithubRef": "dev",
-        "GithubSHA1": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
+        "GithubSHA1": "2796abf30e51de45150a664a6b7d6cebb85f5b90",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-30 16:52:26 UTC; root",
+        "Packaged": "2026-07-01 12:47:43 UTC; root",
         "Author": "Mark Tucker [aut, cre],\n  Matt Urbina [aut],\n  Tim Margheim [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Mark Tucker <mark.tucker@posit.co>",
-        "Built": "R 4.5.3; ; 2026-06-30 16:52:27 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-07-01 12:47:43 UTC; unix"
       }
     },
     "cli": {
@@ -2077,16 +2077,16 @@
         "RemoteRepo": "tibble",
         "RemoteUsername": "tidyverse",
         "RemoteRef": "HEAD",
-        "RemoteSha": "50c178c49fb4a7d1b7bb67bd675ac30b3af33a03",
+        "RemoteSha": "6581b5f249894507133eeb3a990f9c85ac7b2914",
         "GithubRepo": "tibble",
         "GithubUsername": "tidyverse",
         "GithubRef": "HEAD",
-        "GithubSHA1": "50c178c49fb4a7d1b7bb67bd675ac30b3af33a03",
+        "GithubSHA1": "6581b5f249894507133eeb3a990f9c85ac7b2914",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-06-30 16:51:39 UTC; root",
+        "Packaged": "2026-07-01 12:46:58 UTC; root",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Built": "R 4.5.3; x86_64-pc-linux-gnu; 2026-06-30 16:51:40 UTC; unix"
+        "Built": "R 4.5.3; x86_64-pc-linux-gnu; 2026-07-01 12:46:58 UTC; unix"
       }
     },
     "tidyr": {
@@ -2456,7 +2456,7 @@
       "checksum": "28e6f4ef31e1647540845455742ba4c8"
     },
     "renv.lock": {
-      "checksum": "2deb3616a2c2fe3bd945beac1e9777bf"
+      "checksum": "3603b6f4a6b76e7daa8015b9b8e360d9"
     }
   },
   "users": null

--- a/inst/apps/workbench/renv.lock
+++ b/inst/apps/workbench/renv.lock
@@ -577,7 +577,7 @@
       "RemoteRepo": "chronicle-reports",
       "RemoteUsername": "posit-dev",
       "RemoteRef": "dev",
-      "RemoteSha": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
+      "RemoteSha": "2796abf30e51de45150a664a6b7d6cebb85f5b90",
       "NeedsCompilation": "no",
       "Author": "Mark Tucker [aut, cre], Matt Urbina [aut], Tim Margheim [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Mark Tucker <mark.tucker@posit.co>"
@@ -2784,7 +2784,7 @@
       "RemoteRepo": "tibble",
       "RemoteUsername": "tidyverse",
       "RemoteRef": "HEAD",
-      "RemoteSha": "50c178c49fb4a7d1b7bb67bd675ac30b3af33a03",
+      "RemoteSha": "6581b5f249894507133eeb3a990f9c85ac7b2914",
       "NeedsCompilation": "yes",
       "Author": "Kirill Müller [aut, cre] (ORCID: <https://orcid.org/0000-0002-1416-3412>), Hadley Wickham [aut], Romain Francois [ctb], Jennifer Bryan [ctb], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Kirill Müller <kirill@cynkra.com>"

--- a/inst/apps/workbench/renv.lock
+++ b/inst/apps/workbench/renv.lock
@@ -576,8 +576,8 @@
       "RemoteHost": "api.github.com",
       "RemoteRepo": "chronicle-reports",
       "RemoteUsername": "posit-dev",
-      "RemoteRef": "main",
-      "RemoteSha": "ffef35926647ba63480b7f07449855654746482e",
+      "RemoteRef": "dev",
+      "RemoteSha": "bad506d36b866dfae4008417f2ca84d01f1e0b8b",
       "NeedsCompilation": "no",
       "Author": "Mark Tucker [aut, cre], Matt Urbina [aut], Tim Margheim [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Mark Tucker <mark.tucker@posit.co>"


### PR DESCRIPTION
After manually updating the apps manifest files, it looks like the update manifest job properly kept the version bump in the manifest.

Here is the update manifest job that ran which updated only the `ref` properly: https://github.com/posit-dev/chronicle-reports/pull/140/changes/1fb72c374ea60af01080f6e702430ad7e95665c4