### PR TITLE
Add message for no Data

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -89,6 +89,35 @@ chronicle_list_dirs <- function(path) {
   }
 }
 
+#' Check whether a Chronicle dataset directory exists
+#'
+#' Works with both local filesystem paths and S3 URIs. On S3 a "directory"
+#' exists when any objects are stored under the prefix. If the S3 existence
+#' check itself fails (e.g., a credentials problem), returns TRUE so that
+#' [arrow::open_dataset()] surfaces the real error instead of the path being
+#' misclassified as missing.
+#'
+#' @param path Directory path (local or s3://)
+#'
+#' @return TRUE if the path exists, FALSE otherwise
+#'
+#' @keywords internal
+#' @noRd
+chronicle_dataset_exists <- function(path) {
+  if (!startsWith(path, "s3://")) {
+    return(dir.exists(path))
+  }
+
+  tryCatch(
+    {
+      fs <- chronicle_fs(path)
+      info <- fs$GetFileInfo("")[[1]]
+      info$type != arrow::FileType$NotFound
+    },
+    error = function(e) TRUE
+  )
+}
+
 #' Load raw Chronicle data (Advanced)
 #'
 #' Loads raw Chronicle metric data. **Most users should use [chronicle_data()]
@@ -172,7 +201,11 @@ chronicle_raw_data <- function(
 #' @param metric Name of the curated metric to retrieve (e.g., "connect/user_totals")
 #' @param base_path Base path to Chronicle data directory
 #'
-#' @return Arrow dataset object
+#' @return Arrow dataset object, or `NULL` (with a message) when the curated
+#'   dataset directory does not exist yet -- for example on a new install
+#'   where the Chronicle Agent has not completed its first
+#'   collection and curation cycle, or when data for that product is not
+#'   being collected.
 #' @export
 #'
 #' @examples
@@ -200,6 +233,19 @@ chronicle_data <- function(
   base_path = Sys.getenv("CHRONICLE_BASE_PATH", APP_CONFIG$DEFAULT_BASE_PATH)
 ) {
   path <- chronicle_path(base_path, metric, "curated")
+
+  if (!chronicle_dataset_exists(path)) {
+    message(
+      "Chronicle dataset '",
+      metric,
+      "' not found at ",
+      path,
+      " -- the dataset has not been curated yet. Confirm that Chronicle ",
+      "data collection is enabled for this product, that at least 30 hours ",
+      "have passed since collection began, and that base_path is correct."
+    )
+    return(NULL)
+  }
 
   arrow::open_dataset(
     chronicle_fs(path),

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -8,6 +8,7 @@ Connect's
 connectapi
 cph
 cre
+curation
 dev
 devtools
 dplyr

--- a/inst/apps/connect/app.R
+++ b/inst/apps/connect/app.R
@@ -50,35 +50,38 @@ initial_date_start <- function(min_date) {
   }
 }
 
-# Show a popup warning (once per session per dataset) when a
-# curated dataset directory does not exist yet, so users get actionable
-# guidance.
+# Show a popup warning when a curated dataset directory does not exist yet,
+# so users get actionable guidance. All missing datasets share one persistent
+# notification -- re-shown with the same id, it updates in place with the
+# growing list rather than stacking a popup per dataset.
 notify_missing_dataset <- function(metric) {
   session <- shiny::getDefaultReactiveDomain()
   if (is.null(session)) {
     return(invisible(NULL))
   }
-  seen <- session$userData$missing_datasets_notified
-  if (metric %in% seen) {
+  missing <- session$userData$missing_datasets
+  if (metric %in% missing) {
     return(invisible(NULL))
   }
-  session$userData$missing_datasets_notified <- c(seen, metric)
+  missing <- c(missing, metric)
+  session$userData$missing_datasets <- missing
   shiny::showNotification(
     # overflow-wrap lets long unbroken data paths wrap instead of
     # overflowing the notification
     shiny::div(
       style = "overflow-wrap: anywhere;",
       paste0(
-        "No '",
-        metric,
-        "' data has been curated yet. Confirm that Chronicle data collection ",
-        "is enabled for Posit Connect, that at least 30 hours have passed ",
-        "since collection began, and that the data path ('",
+        "No curated data found for: ",
+        paste0("'", missing, "'", collapse = ", "),
+        ". Confirm that Chronicle data collection is enabled for Posit ",
+        "Connect, that at least 30 hours have passed since collection ",
+        "began, and that the data path ('",
         base_path,
         "') is correct."
       )
     ),
     duration = NULL,
+    id = "chronicle-missing-datasets",
     type = "warning",
     session = session
   )

--- a/inst/apps/connect/app.R
+++ b/inst/apps/connect/app.R
@@ -50,6 +50,41 @@ initial_date_start <- function(min_date) {
   }
 }
 
+# Show a popup warning (once per session per dataset) when a
+# curated dataset directory does not exist yet, so users get actionable
+# guidance.
+notify_missing_dataset <- function(metric) {
+  session <- shiny::getDefaultReactiveDomain()
+  if (is.null(session)) {
+    return(invisible(NULL))
+  }
+  seen <- session$userData$missing_datasets_notified
+  if (metric %in% seen) {
+    return(invisible(NULL))
+  }
+  session$userData$missing_datasets_notified <- c(seen, metric)
+  shiny::showNotification(
+    # overflow-wrap lets long unbroken data paths wrap instead of
+    # overflowing the notification
+    shiny::div(
+      style = "overflow-wrap: anywhere;",
+      paste0(
+        "No '",
+        metric,
+        "' data has been curated yet. Confirm that Chronicle data collection ",
+        "is enabled for Posit Connect, that at least 30 hours have passed ",
+        "since collection began, and that the data path ('",
+        base_path,
+        "') is correct."
+      )
+    ),
+    duration = NULL,
+    type = "warning",
+    session = session
+  )
+  invisible(NULL)
+}
+
 # Brand colors
 BRAND_COLORS <- list(
   BLUE = "#447099",
@@ -2123,6 +2158,10 @@ server <- function(input, output, session) {
     tryCatch(
       {
         ds <- chronicle_data("connect/user_totals", base_path)
+        if (is.null(ds)) {
+          notify_missing_dataset("connect/user_totals")
+          return(NULL)
+        }
         if (!is.null(range)) {
           range_min <- range$min
           range_max <- range$max
@@ -2157,6 +2196,10 @@ server <- function(input, output, session) {
     tryCatch(
       {
         ds <- chronicle_data("connect/user_list", base_path)
+        if (is.null(ds)) {
+          notify_missing_dataset("connect/user_list")
+          return(NULL)
+        }
         max_date <- ds |>
           dplyr::summarise(max_date = max(date, na.rm = TRUE)) |>
           dplyr::collect() |>
@@ -2180,6 +2223,10 @@ server <- function(input, output, session) {
     tryCatch(
       {
         ds <- chronicle_data("connect/content_totals", base_path)
+        if (is.null(ds)) {
+          notify_missing_dataset("connect/content_totals")
+          return(NULL)
+        }
         if (!is.null(range)) {
           range_min <- range$min
           range_max <- range$max
@@ -2211,6 +2258,10 @@ server <- function(input, output, session) {
     tryCatch(
       {
         ds <- chronicle_data("connect/content_list", base_path)
+        if (is.null(ds)) {
+          notify_missing_dataset("connect/content_list")
+          return(NULL)
+        }
         max_date <- ds |>
           dplyr::summarise(max_date = max(date, na.rm = TRUE)) |>
           dplyr::collect() |>
@@ -2247,6 +2298,10 @@ server <- function(input, output, session) {
           "connect/content_hits_totals_by_user",
           base_path
         )
+        if (is.null(ds)) {
+          notify_missing_dataset("connect/content_hits_totals_by_user")
+          return(NULL)
+        }
         if (!is.null(range)) {
           range_min <- range$min
           range_max <- range$max

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -50,35 +50,38 @@ initial_date_start <- function(min_date) {
   }
 }
 
-# Show a popup warning (once per session per dataset) when a
-# curated dataset directory does not exist yet, so users get actionable
-# guidance.
+# Show a popup warning when a curated dataset directory does not exist yet,
+# so users get actionable guidance. All missing datasets share one persistent
+# notification -- re-shown with the same id, it updates in place with the
+# growing list rather than stacking a popup per dataset.
 notify_missing_dataset <- function(metric) {
   session <- shiny::getDefaultReactiveDomain()
   if (is.null(session)) {
     return(invisible(NULL))
   }
-  seen <- session$userData$missing_datasets_notified
-  if (metric %in% seen) {
+  missing <- session$userData$missing_datasets
+  if (metric %in% missing) {
     return(invisible(NULL))
   }
-  session$userData$missing_datasets_notified <- c(seen, metric)
+  missing <- c(missing, metric)
+  session$userData$missing_datasets <- missing
   shiny::showNotification(
     # overflow-wrap lets long unbroken data paths wrap instead of
     # overflowing the notification
     shiny::div(
       style = "overflow-wrap: anywhere;",
       paste0(
-        "No '",
-        metric,
-        "' data has been curated yet. Confirm that Chronicle data collection ",
-        "is enabled for Posit Workbench, that at least 30 hours have passed ",
-        "since collection began, and that the data path ('",
+        "No curated data found for: ",
+        paste0("'", missing, "'", collapse = ", "),
+        ". Confirm that Chronicle data collection is enabled for Posit ",
+        "Workbench, that at least 30 hours have passed since collection ",
+        "began, and that the data path ('",
         base_path,
         "') is correct."
       )
     ),
     duration = NULL,
+    id = "chronicle-missing-datasets",
     type = "warning",
     session = session
   )

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -50,6 +50,41 @@ initial_date_start <- function(min_date) {
   }
 }
 
+# Show a popup warning (once per session per dataset) when a
+# curated dataset directory does not exist yet, so users get actionable
+# guidance.
+notify_missing_dataset <- function(metric) {
+  session <- shiny::getDefaultReactiveDomain()
+  if (is.null(session)) {
+    return(invisible(NULL))
+  }
+  seen <- session$userData$missing_datasets_notified
+  if (metric %in% seen) {
+    return(invisible(NULL))
+  }
+  session$userData$missing_datasets_notified <- c(seen, metric)
+  shiny::showNotification(
+    # overflow-wrap lets long unbroken data paths wrap instead of
+    # overflowing the notification
+    shiny::div(
+      style = "overflow-wrap: anywhere;",
+      paste0(
+        "No '",
+        metric,
+        "' data has been curated yet. Confirm that Chronicle data collection ",
+        "is enabled for Posit Workbench, that at least 30 hours have passed ",
+        "since collection began, and that the data path ('",
+        base_path,
+        "') is correct."
+      )
+    ),
+    duration = NULL,
+    type = "warning",
+    session = session
+  )
+  invisible(NULL)
+}
+
 # Brand colors
 BRAND_COLORS <- list(
   BLUE = "#447099",
@@ -232,6 +267,10 @@ users_overview_server <- function(input, output, session) {
     tryCatch(
       {
         ds <- chronicle_data("workbench/user_totals", base_path)
+        if (is.null(ds)) {
+          notify_missing_dataset("workbench/user_totals")
+          return(NULL)
+        }
         if (!is.null(range)) {
           range_min <- range$min
           range_max <- range$max
@@ -1732,6 +1771,10 @@ sessions_by_user_server <- function(
           "workbench/session_start_totals_by_user",
           base_path
         )
+        if (is.null(ds)) {
+          notify_missing_dataset("workbench/session_start_totals_by_user")
+          return(NULL)
+        }
         if (!is.null(range)) {
           range_min <- range$min
           range_max <- range$max
@@ -2373,6 +2416,10 @@ server <- function(input, output, session) {
     tryCatch(
       {
         data <- chronicle_data("workbench/user_list", base_path)
+        if (is.null(data)) {
+          notify_missing_dataset("workbench/user_list")
+          return(NULL)
+        }
 
         # Find max_date in Arrow (reads only parquet metadata), then collect
         # just that partition instead of all historical snapshots
@@ -2422,6 +2469,10 @@ server <- function(input, output, session) {
     tryCatch(
       {
         ds <- chronicle_data("workbench/session_start_totals", base_path)
+        if (is.null(ds)) {
+          notify_missing_dataset("workbench/session_start_totals")
+          return(NULL)
+        }
         if (!is.null(range)) {
           range_min <- range$min
           range_max <- range$max
@@ -2480,6 +2531,10 @@ server <- function(input, output, session) {
     tryCatch(
       {
         ds <- chronicle_data("workbench/session_duration", base_path)
+        if (is.null(ds)) {
+          notify_missing_dataset("workbench/session_duration")
+          return(NULL)
+        }
         if (!is.null(range)) {
           range_min <- range$min
           range_max <- range$max

--- a/man/chronicle.reports-package.Rd
+++ b/man/chronicle.reports-package.Rd
@@ -22,6 +22,7 @@ Useful links:
 Authors:
 \itemize{
   \item Matt Urbina \email{matt.urbina@posit.co}
+  \item Tim Margheim \email{tim.margheim@posit.co}
 }
 
 Other contributors:

--- a/man/chronicle_data.Rd
+++ b/man/chronicle_data.Rd
@@ -15,7 +15,11 @@ chronicle_data(
 \item{base_path}{Base path to Chronicle data directory}
 }
 \value{
-Arrow dataset object
+Arrow dataset object, or \code{NULL} (with a message) when the curated
+dataset directory does not exist yet -- for example on a new install
+where the Chronicle Agent has not completed its first
+collection and curation cycle, or when data for that product is not
+being collected.
 }
 \description{
 Loads curated Chronicle metric data. This is the

--- a/tests/testthat/test_chronicle_data.R
+++ b/tests/testthat/test_chronicle_data.R
@@ -294,20 +294,30 @@ test_that("chronicle_data can be used with dplyr operations", {
   expect_true(result$max_active <= result$avg_users) # Max active should be <= avg named users
 })
 
-test_that("chronicle_data handles non-existent metric gracefully", {
+test_that("chronicle_data returns NULL with a message for missing datasets", {
   base_path <- create_sample_chronicle_data()
   on.exit(unlink(base_path, recursive = TRUE))
 
-  # Try to load a metric that doesn't exist
-  # Arrow's open_dataset doesn't error immediately (lazy evaluation)
-  # But trying to collect should fail with IOError about missing directory
-  expect_error(
-    {
-      data <- chronicle_data("fake/metric", base_path)
-      dplyr::collect(data)
-    },
-    regexp = "(IOError|does not exist|no such file)"
+  # Loading a metric whose curated directory doesn't exist should not raise
+  # Arrow's opaque IOError. Instead it returns NULL with a message that
+  # classifies the problem as "not curated yet" and names the metric.
+  expect_message(
+    data <- chronicle_data("fake/metric", base_path),
+    regexp = "'fake/metric' not found.*not been curated yet"
   )
+  expect_null(data)
+})
+
+test_that("chronicle_data returns NULL when the base path itself is missing", {
+  # A new install where the agent hasn't produced anything yet
+  expect_message(
+    data <- chronicle_data(
+      "connect/user_totals",
+      file.path(tempdir(), "does-not-exist")
+    ),
+    regexp = "not been curated yet"
+  )
+  expect_null(data)
 })
 
 test_that("chronicle_data preserves data integrity", {


### PR DESCRIPTION
Adds shiny `showNotification` to help inform users running the app when no data exists. Also surfaces the path being used when no data is found for a given curated metric.

Example for Connect
<img width="1400" height="878" alt="connect_missing_all_page" src="https://github.com/user-attachments/assets/3dd890b8-2824-4ff4-b67b-41f0cf96df3a" />


If there's multiple missing metrics, we will populate the notification with all missing curated metrics.
<img width="1400" height="907" alt="workbench_multi_missing_page" src="https://github.com/user-attachments/assets/ab3bdc4b-8ec8-4bd7-99f8-1f9c409c5f37" />
