### PR TITLE
docs: reword Chronicle gallery feed descriptions

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -3,7 +3,7 @@
     {
       "id": "chronicle-reports",
       "title": "Chronicle Reports",
-      "description": "Usage analytics dashboards powered by Posit Chronicle data."
+      "description": "Pre-built dashboards for exploring the Connect and Workbench usage data collected by Posit Chronicle."
     }
   ],
   "tags": [
@@ -14,7 +14,7 @@
     {
       "name": "connect",
       "title": "Chronicle Connect Dashboard",
-      "description": "Comprehensive Posit Connect usage analytics — tracks licensed users, daily active users, publishers, content metrics, and usage patterns over time.",
+      "description": "Track how your organization uses Posit Connect: licensed users, daily active users, publishers, content, and activity trends over time, from data collected by Posit Chronicle.",
       "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/connect",
       "latestVersion": {
         "version": "1.0.0",
@@ -59,7 +59,7 @@
     {
       "name": "workbench",
       "title": "Chronicle Workbench Dashboard",
-      "description": "Comprehensive Posit Workbench usage analytics — tracks licensed users, daily active users, session metrics, and admin activity over time.",
+      "description": "Track how your organization uses Posit Workbench: licensed users, daily active users, sessions, and admin activity over time, from data collected by Posit Chronicle. If you don't run Workbench, this dashboard will have no data.",
       "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/workbench",
       "latestVersion": {
         "version": "1.0.0",

--- a/gallery.json
+++ b/gallery.json
@@ -3,7 +3,7 @@
     {
       "id": "chronicle-reports",
       "title": "Chronicle Reports",
-      "description": "Usage analytics dashboards powered by Posit Chronicle data."
+      "description": "Pre-built dashboards for exploring the Connect and Workbench usage data collected by Posit Chronicle."
     }
   ]
 }

--- a/inst/apps/connect/manifest.json
+++ b/inst/apps/connect/manifest.json
@@ -2,7 +2,7 @@
   "extension": {
     "name": "connect",
     "title": "Chronicle Connect Dashboard",
-    "description": "Comprehensive Posit Connect usage analytics — tracks licensed users, daily active users, publishers, content metrics, and usage patterns over time.",
+    "description": "Track how your organization uses Posit Connect: licensed users, daily active users, publishers, content, and activity trends over time, from data collected by Posit Chronicle.",
     "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/connect",
     "category": "chronicle-reports",
     "tags": [

--- a/inst/apps/workbench/manifest.json
+++ b/inst/apps/workbench/manifest.json
@@ -2,7 +2,7 @@
   "extension": {
     "name": "workbench",
     "title": "Chronicle Workbench Dashboard",
-    "description": "Comprehensive Posit Workbench usage analytics — tracks licensed users, daily active users, session metrics, and admin activity over time.",
+    "description": "Track how your organization uses Posit Workbench: licensed users, daily active users, sessions, and admin activity over time, from data collected by Posit Chronicle. If you don't run Workbench, this dashboard will have no data.",
     "homepage": "https://github.com/posit-dev/chronicle-reports/tree/main/inst/apps/workbench",
     "category": "chronicle-reports",
     "tags": [


### PR DESCRIPTION
Fixes #145.

The chronicle-reports feed is becoming a default gallery feed in Connect (posit-dev/connect#41144), so these descriptions now surface to every Connect user in the gallery. This rewords the category description and both dashboard descriptions to:

- match the capability-forward voice of the other gallery descriptions,
- (Workbench) note that the dashboard will be empty without Workbench data. Connect has no way to detect whether an organization runs Workbench, so the card always shows to everyone; the extra sentence sets that expectation.