### PR TITLE
feat: require Posit Chronicle for the gallery dashboards

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # chronicle.reports
 
+* The Connect and Workbench dashboards now declare that they require Posit Chronicle, so the Connect Gallery shows how to enable it when Chronicle is not running.
+
 # chronicle.reports 1.0.0
 
 * Added Workbench session reporting. These new reports require additional curated datasets: `workbench/session_start_totals`, `workbench/session_start_totals_by_user` and `workbench/session_duration` available in Workbench 2026.06.0 and later.

--- a/inst/apps/connect/manifest.json
+++ b/inst/apps/connect/manifest.json
@@ -9,7 +9,9 @@
       "Chronicle reports"
     ],
     "minimumConnectVersion": "2026.06.0",
-    "requiredFeatures": [],
+    "requiredFeatures": [
+      "Posit Chronicle"
+    ],
     "version": "1.0.0"
   },
   "version": 1,

--- a/inst/apps/workbench/manifest.json
+++ b/inst/apps/workbench/manifest.json
@@ -9,7 +9,9 @@
       "Chronicle reports"
     ],
     "minimumConnectVersion": "2026.06.0",
-    "requiredFeatures": [],
+    "requiredFeatures": [
+      "Posit Chronicle"
+    ],
     "version": "1.0.0"
   },
   "version": 1,


### PR DESCRIPTION
If a user does not have Chronicle set up, the Gallery should now show a "How to Upgrade" button with instructions on how to set up Chronicle (for the two dashboards that use Chronicle) instead of the generic "Add" button: issue posit-dev/connect#41145, PR posit-dev/connect#41375. 

This PR tags the Connect and Workbench dashboards so that behavior applies to them.