### PR TITLE
move download icon for user summary page

### DIFF
--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -1750,7 +1750,7 @@ sessions_duration_server <- function(input, output, session, duration_data) {
 # ==============================================
 
 sessions_by_user_ui <- bslib::card(
-  card_header_with_download("Filters", "download_user_summary"),
+  bslib::card_header("Filters"),
   bslib::layout_columns(
     col_widths = c(4, 4, 4),
     shiny::dateRangeInput(
@@ -1771,8 +1771,11 @@ sessions_by_user_ui <- bslib::card(
       placeholder = "User"
     )
   ),
-  shinycssloaders::withSpinner(
-    DT::dataTableOutput("sessions_by_user_table")
+  bslib::card(
+    card_header_with_download("User Sessions", "download_user_summary"),
+    shinycssloaders::withSpinner(
+      DT::dataTableOutput("sessions_by_user_table")
+    )
   )
 )
 


### PR DESCRIPTION
This is claude-written. I've tested manually. Moved the download icon to the table.

<img width="1191" height="738" alt="image" src="https://github.com/user-attachments/assets/182cfcd5-ce33-49f7-b3ff-9ed6dc92037e" />

---

This pull request refactors the UI structure for the "Sessions by User" section in `inst/apps/workbench/app.R` to improve clarity and separation of concerns. The download button for user session data is now associated with the data table rather than the filters.

**UI Improvements:**

* Moved the download button for user session data from the filters card header to a new card header above the sessions data table, using `card_header_with_download("User Sessions", "download_user_summary")`. [[1]](diffhunk://#diff-27b8849687d067ace261aa671f785cd0cae873361f7c5f828e02bf572e111d5cL1753-R1753) [[2]](diffhunk://#diff-27b8849687d067ace261aa671f785cd0cae873361f7c5f828e02bf572e111d5cR1774-R1780)
* The filters section now uses a simpler `bslib::card_header("Filters")` without the download button, clarifying its purpose.