### PR TITLE
Move download icons

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,9 +40,10 @@ Suggests:
     tibble (>= 3.3.0)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 Remotes:
     r-lib/devtools,
     tidyverse/tibble,
     r-lib/withr
+Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.2

--- a/R/run_app.R
+++ b/R/run_app.R
@@ -6,9 +6,6 @@
 #'
 #' @param app_name Name of the app to run. Available apps:
 #'   \itemize{
-#'     \item `"connect_users"` - Connect Users Dashboard (legacy, raw data)
-#'     \item `"workbench_users"` - Workbench Users Dashboard (legacy, raw data)
-#'     \item `"connect_user_totals"` - Connect Users Dashboard (curated data)
 #'     \item `"connect"` - Comprehensive Connect Dashboard
 #'     \item `"workbench"` - Comprehensive Workbench Dashboard
 #'   }
@@ -32,13 +29,13 @@
 #'   chronicle_list_apps()
 #'
 #'   # Run an app with default data path
-#'   chronicle_run_app("connect_users")
+#'   chronicle_run_app("connect")
 #'
 #'   # Run an app with custom filesystem path
-#'   chronicle_run_app("connect_users", "/path/to/chronicle/data")
+#'   chronicle_run_app("connect", "/path/to/chronicle/data")
 #'
 #'   # Run an app with S3 path
-#'   chronicle_run_app("connect_users", "s3://chronicle-bucket/data")
+#'   chronicle_run_app("connect", "s3://chronicle-bucket/data")
 #' }
 chronicle_run_app <- function(
   app_name,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Chronicle Reports
 
 > [!NOTE]
-> For data collected by Chronicle `v2026.1.0` or earlier, use `v0.2.2` of these reports. 
+> For data collected by Chronicle `v2026.1.0` or earlier, use `v0.2.2` of these reports.
 > To install using pak: `pak::pak("posit-dev/chronicle-reports@v0.2.2")`.
 
 Chronicle Reports is an R package that provides pre-built Shiny dashboards and data access tools for analyzing usage data from Posit Chronicle. Chronicle helps organizations understand their use of Posit Connect and Posit Workbench through comprehensive metrics on users, content, and activity patterns. See the [Chronicle announcement](https://posit.co/blog/chronicle-product-announcement-aug-2025/) for more details.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -37,6 +37,7 @@ programmatically
 rlang
 ROR
 Roxygen
+roxygen
 RoxygenNote
 shinycssloaders
 shinytest

--- a/inst/apps/connect/app.R
+++ b/inst/apps/connect/app.R
@@ -504,11 +504,7 @@ users_overview_server <- function(input, output, session, user_totals) {
 # ==============================================
 
 users_list_ui <- bslib::card(
-  card_header_with_download(
-    "Filters",
-    "download_users_list",
-    shiny::textOutput("users_list_as_of", inline = TRUE)
-  ),
+  bslib::card_header("Filters"),
   bslib::layout_columns(
     col_widths = c(6, 6),
     shiny::selectInput(
@@ -522,8 +518,15 @@ users_list_ui <- bslib::card(
       choices = c("All", "publisher", "viewer", "administrator")
     )
   ),
-  shinycssloaders::withSpinner(
-    DT::dataTableOutput("users_list_table")
+  bslib::card(
+    card_header_with_download(
+      "Users",
+      "download_users_list",
+      shiny::textOutput("users_list_as_of", inline = TRUE)
+    ),
+    shinycssloaders::withSpinner(
+      DT::dataTableOutput("users_list_table")
+    )
   )
 )
 
@@ -1091,7 +1094,7 @@ content_overview_server <- function(input, output, session, content_totals) {
 # ==============================================
 
 content_list_ui <- bslib::card(
-  card_header_with_download("Content List", "download_content_list"),
+  bslib::card_header("Filters"),
   bslib::layout_columns(
     col_widths = c(4, 4, 4),
     shiny::selectInput(
@@ -1110,8 +1113,11 @@ content_list_ui <- bslib::card(
       choices = c("All")
     )
   ),
-  shinycssloaders::withSpinner(
-    DT::dataTableOutput("content_list_table")
+  bslib::card(
+    card_header_with_download("Content List", "download_content_list"),
+    shinycssloaders::withSpinner(
+      DT::dataTableOutput("content_list_table")
+    )
   )
 )
 
@@ -1706,10 +1712,7 @@ content_hits_overview_server <- function(
 # ==============================================
 
 content_hits_by_user_ui <- bslib::card(
-  card_header_with_download(
-    "Content Hits by User",
-    "download_content_hits_by_user"
-  ),
+  bslib::card_header("Filters"),
   bslib::layout_columns(
     col_widths = c(4, 8),
     shiny::selectInput(
@@ -1725,8 +1728,14 @@ content_hits_by_user_ui <- bslib::card(
       format = "yyyy-mm-dd"
     )
   ),
-  shinycssloaders::withSpinner(
-    DT::dataTableOutput("content_hits_by_user_table")
+  bslib::card(
+    card_header_with_download(
+      "Content Hits by User",
+      "download_content_hits_by_user"
+    ),
+    shinycssloaders::withSpinner(
+      DT::dataTableOutput("content_hits_by_user_table")
+    )
   )
 )
 

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -591,7 +591,7 @@ users_overview_server <- function(input, output, session) {
 # ==============================================
 
 user_list_ui <- bslib::card(
-  card_header_with_download("Filters", "download_user_list"),
+  bslib::card_header("Filters"),
   bslib::layout_columns(
     col_widths = c(4, 4, 4),
     shiny::selectInput(
@@ -610,8 +610,11 @@ user_list_ui <- bslib::card(
       placeholder = "Username"
     )
   ),
-  shinycssloaders::withSpinner(
-    DT::dataTableOutput("user_list_table")
+  bslib::card(
+    card_header_with_download("Users", "download_user_list"),
+    shinycssloaders::withSpinner(
+      DT::dataTableOutput("user_list_table")
+    )
   )
 )
 

--- a/inst/apps/workbench/app.R
+++ b/inst/apps/workbench/app.R
@@ -1750,7 +1750,7 @@ sessions_duration_server <- function(input, output, session, duration_data) {
 # ==============================================
 
 sessions_by_user_ui <- bslib::card(
-  card_header_with_download("Filters", "download_user_summary"),
+  bslib::card_header("Filters"),
   bslib::layout_columns(
     col_widths = c(4, 4, 4),
     shiny::dateRangeInput(
@@ -1771,8 +1771,11 @@ sessions_by_user_ui <- bslib::card(
       placeholder = "User"
     )
   ),
-  shinycssloaders::withSpinner(
-    DT::dataTableOutput("sessions_by_user_table")
+  bslib::card(
+    card_header_with_download("User Sessions", "download_user_summary"),
+    shinycssloaders::withSpinner(
+      DT::dataTableOutput("sessions_by_user_table")
+    )
   )
 )
 

--- a/man/chronicle_run_app.Rd
+++ b/man/chronicle_run_app.Rd
@@ -12,9 +12,6 @@ chronicle_run_app(
 \arguments{
 \item{app_name}{Name of the app to run. Available apps:
 \itemize{
-\item \code{"connect_users"} - Connect Users Dashboard (legacy, raw data)
-\item \code{"workbench_users"} - Workbench Users Dashboard (legacy, raw data)
-\item \code{"connect_user_totals"} - Connect Users Dashboard (curated data)
 \item \code{"connect"} - Comprehensive Connect Dashboard
 \item \code{"workbench"} - Comprehensive Workbench Dashboard
 }
@@ -43,12 +40,12 @@ if (interactive()) {
   chronicle_list_apps()
 
   # Run an app with default data path
-  chronicle_run_app("connect_users")
+  chronicle_run_app("connect")
 
   # Run an app with custom filesystem path
-  chronicle_run_app("connect_users", "/path/to/chronicle/data")
+  chronicle_run_app("connect", "/path/to/chronicle/data")
 
   # Run an app with S3 path
-  chronicle_run_app("connect_users", "s3://chronicle-bucket/data")
+  chronicle_run_app("connect", "s3://chronicle-bucket/data")
 }
 }


### PR DESCRIPTION
Move all download icons into tables, rather than next to the "Filters" section.

I've manually checked all tabs for both the Connect and Workbench reports, but would be happy to get another set of eyes on it as part of this PR review. In an R console:

```
devtools::load_all()
sd <- chronicle.reports::chronicle_sample_data()
chronicle.reports::chronicle_run_app("workbench", sd)
chronicle.reports::chronicle_run_app("connect", sd)
```

---

Separately, I noticed that the tooltip/typeahead for chronicle_run_app was not right:

<img width="1259" height="478" alt="image" src="https://github.com/user-attachments/assets/04d09d2b-9d2d-4906-81f1-6d7743110c2b" />

With the changes in this PR (8202cd17066faa867b61630e469d2fa5278bb0c9), this now shows the correct app names:

<img width="1273" height="438" alt="image" src="https://github.com/user-attachments/assets/5afb7c1a-2dc7-4901-a761-ec1bdc06935d" />

