### PR TITLE
feat: mark the Connect and Workbench dashboards as admin-only

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -54,7 +54,8 @@
       "tags": [
         "Chronicle reports"
       ],
-      "category": "chronicle-reports"
+      "category": "chronicle-reports",
+      "adminOnly": true
     },
     {
       "name": "workbench",
@@ -99,7 +100,8 @@
       "tags": [
         "Chronicle reports"
       ],
-      "category": "chronicle-reports"
+      "category": "chronicle-reports",
+      "adminOnly": true
     }
   ]
 }


### PR DESCRIPTION
Connect will support an `adminOnly` flag on gallery extensions (posit-dev/connect#41146, PR posit-dev/connect#41701), which hides an extension's gallery listing and deploy button from non-administrators. Since these Chronicle dashboards are intended for admins, this PR marks them accordingly.